### PR TITLE
chore(Makefile): switch OFF of alpine-based dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILD_TAG := git-${GIT_SHA}
 
 # The following variables describe the containerized development environment
 # and other build options
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.1.0-alpine
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.1.0
 DEV_ENV_WORK_DIR := /go/src/github.com/deis/${SHORT_NAME}
 DEV_ENV_CMD := docker run --rm -v ${PWD}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
 DEV_ENV_CMD_INT := docker run -it --rm -v ${PWD}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
@@ -29,7 +29,7 @@ SVC := manifests/deis-${SHORT_NAME}-service.yaml
 
 # Allow developers to step into the containerized development environment
 dev: check-docker
-	${DEV_ENV_CMD_INT} ash
+	${DEV_ENV_CMD_INT} bash
 
 dev-registry: check-docker
 	@docker inspect registry >/dev/null 2>&1 && docker start registry || docker run --restart="always" -d -p 5000:5000 --name registry registry:0.9.1


### PR DESCRIPTION
This reverts commit 8faef2cc3c05ebd85023f12a8085c4c6cef0d539.

This experiment failed pretty quickly.  Although I _could_ get stable builds from it, I started running into numerous other issues in the alpine-based dev environment.  afaict, there were some pretty significant problems with volumes mounted from the host (i.e. the project's working directory).  I could make changes to files on my Mac and then back in the container, some containerized programs (it would seem just ones that open files for write, such as vi) would _see_ the changes, while others such as cat and grep would not.  To me this smells like some sort of file system issue and it's something we can't afford the time to troubleshoot right now when a working dev environment already exists.