### PR TITLE
feat(Makefile): add make targets for testing

### DIFF
--- a/includes.mk
+++ b/includes.mk
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 check-docker:
 	@if [ -z $$(which docker) ]; then \
 		echo "Missing \`docker\` client which is required for development"; \


### PR DESCRIPTION
This PR adds a variety of make targets as placeholders for containerized test processes.  The one that is fully implemented is the style checks.

After this PR, `make test`, actually works, which means I can also get going on integrating this with CI.