### PR TITLE
feat(router): support stream for builder

### DIFF
--- a/nginx/config.go
+++ b/nginx/config.go
@@ -46,6 +46,15 @@ http {
 
 	{{end}}{{end}}
 }
+
+{{ if $routerConfig.BuilderConfig }}{{ $builderConfig := $routerConfig.BuilderConfig }}stream {
+	server {
+		listen 2222;
+		proxy_connect_timeout {{ $builderConfig.ConnectTimeout }};
+		proxy_timeout {{ $builderConfig.TCPTimeout }};
+		proxy_pass {{$builderConfig.ServiceIP}}:2222;
+	}
+}{{ end }}
 `
 )
 


### PR DESCRIPTION
Attn: @arschles 

While adding support for the builder, I stumbled across the edge case of missing annotations.  In the case of builder, I can roll with defaults.  Awareness of this edge case and my technique for handling it did lead to a more general refactor of how this chunk of code builds the model, that and a liberal sprinkling of new comments to explain what the hell I'm doing.  Please forgive that slight scope creep.

~~If you want to use this with builder (as installed by helm), there's only one thing you actually need to do-- you need to move the builder's service into the "deis" namespace.  Moving all the deis components into the "deis" namespace has been a previous topic of discussion and has been something we'll "get around to at some point."  I guess it's time?  (It sort of matters to the router, because the router goes _looking_ for deis-builder and it really does need to know what namespace to look in.)  We could discuss this at greater length tomorrow.  cc: @technosophos @mboersma~~ This was addressed by https://github.com/deis/charts/pull/12

~~Apart from that, the remainder of~~ the configuration is optional.  You can, but don't have to, do the following in the manifest for the deis-builder:

```
apiVersion: v1
kind: Service
metadata:
  annotations:
    routerConfig: '{"connectTimeout":10000,"tcpTimeout":1200000}'
...
```

The values shown are the defaults you get if you don't add a `routerConfig` annotation.