### PR TITLE
feat(router): make platform domain configurable

### DIFF
--- a/manifests/deis-router-rc.yaml
+++ b/manifests/deis-router-rc.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     routerConfig: |
       {
+        "domain": "example.com",
         "useProxyProtocol": false
       }
 spec:

--- a/manifests/examples.yaml
+++ b/manifests/examples.yaml
@@ -27,7 +27,7 @@ metadata:
     routable: "true"
     app: nginx
   annotations:
-    routerConfig: '{"domains":["nginx.example.com"]}'
+    routerConfig: '{"domains":["nginx"]}'
 spec:
   ports:
   - port: 80
@@ -65,7 +65,8 @@ metadata:
     routable: "true"
     app: apache
   annotations:
-    routerConfig: '{"domains":["apache.example.com","httpd.example.com"]}'
+    # Demonstrates a subdomain of the platform's domain as well as a custom domain
+    routerConfig: '{"domains":["apache","httpd.example.com"]}'
 spec:
   ports:
   - port: 80


### PR DESCRIPTION
Before this PR, routable services could be annotated with a list of domains, but that meant if someone wanted to change their "platform domain," every routable service would require its annotations to be updated-- no bueno.

This PR allows the platform domain (e.g. example.com) to be configured at the _router_ level and any "domains" defined on a routable application that do not contain any periods will be assumed to be subdomains of the platform domain when the router builds its configuration model.