### PR TITLE
chore(router): use downward api to set POD_NAMESPACE env var

### DIFF
--- a/manifests/deis-router-rc.yaml
+++ b/manifests/deis-router-rc.yaml
@@ -25,8 +25,10 @@ spec:
         image: ## Image is dynamically set by `make set-image` as part of dev deployment ##
         imagePullPolicy: Always
         env:
-        - name: NAMESPACE
-          value: deis
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
         - containerPort: 80
           hostPort: 80

--- a/model/model.go
+++ b/model/model.go
@@ -54,7 +54,7 @@ func newBuilderConfig() *BuilderConfig {
 var namespace string
 
 func init() {
-	namespace = utils.GetOpt("NAMESPACE", "default")
+	namespace = utils.GetOpt("POD_NAMESPACE", "default")
 }
 
 // Build creates a RouterConfig configuration object by querying the k8s API for


### PR DESCRIPTION
This is insipired by deis/charts#23

For consistency, I also renamed the env variable to `POD_NAMESPACE`