### PR TITLE
feat(router): support configuration of worker procs and connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Note that although the annotation containing router configuration for each of th
 
 | Component            | Name             | Type       | Default Value | Description |
 |----------------------|------------------|------------|---------------|-------------|
+| deis-router          | workerProcesses  | `string`   | `auto` (number of CPU cores) | Number of worker processes to start. |
+| deis-router          | workerConnections | `integer` | `768`         | Maximum number of simultaneous connections that can be opened by a worker process. |
 | deis-router          | defaultTimeout   | `integer`  | 1300          | Default timeout value in seconds.  Should be greater than the front-facing load balancer's timeout value. |
 | deis-router          | domain           | `string`   | N/A           | This defines the router's default domain.  Any domains added to a routable application _not_ containing the `.` character will be assumed to be subdomains of this default domain.  Thus, for example, a default domain of `example.com` coupled with a routable app counting `foo` among its domains will result in router configuration that routes traffic for `foo.example.com` to that application. |
 | deis-router          | useProxyProtocol | `boolean`  | `false`       | PROXY is a simple protocol supported by nginx, HAProxy, Amazon ELB, and others.  It provides a method to obtain information about a request's originating IP address from an external (to Kubernetes) load balancer in front of the router.  Enabling this option allows the router to select the originating IP from the HTTP `X-Forwarded-For` header. |

--- a/model/model.go
+++ b/model/model.go
@@ -14,17 +14,21 @@ import (
 
 // RouterConfig is the primary type used to encapsulate all router configuration.
 type RouterConfig struct {
-	DefaultTimeout   int    `json:"defaultTimeout"`
-	Domain           string `json:"domain"`
-	UseProxyProtocol bool   `json:"useProxyProtocol"`
-	AppConfigs       []*AppConfig
-	BuilderConfig    *BuilderConfig
+	WorkerProcesses      string `json:"workerProcesses"`
+	MaxWorkerConnections int    `json:"maxWorkerConnections"`
+	DefaultTimeout       int    `json:"defaultTimeout"`
+	Domain               string `json:"domain"`
+	UseProxyProtocol     bool   `json:"useProxyProtocol"`
+	AppConfigs           []*AppConfig
+	BuilderConfig        *BuilderConfig
 }
 
 func newRouterConfig() *RouterConfig {
 	return &RouterConfig{
-		DefaultTimeout:   1300,
-		UseProxyProtocol: false,
+		WorkerProcesses:      "auto",
+		MaxWorkerConnections: 768,
+		DefaultTimeout:       1300,
+		UseProxyProtocol:     false,
 	}
 }
 

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -11,8 +11,11 @@ const (
 	confTemplate = `{{ $routerConfig := . }}user nginx;
 daemon off;
 
+worker_processes {{ $routerConfig.WorkerProcesses }};
+
 events {
-	worker_connections 1024;
+	worker_connections {{ $routerConfig.MaxWorkerConnections }};
+	# multi_accept on;
 }
 
 http {


### PR DESCRIPTION
This is the first of many PRs that will incrementally bring the router into feature parity with the v1.x router.

~~Note I have designated this as a WIP because it will require rebase and further doc modifications after #27 is merged.~~