### PR TITLE
feat(router): configure "basic settings"

### DIFF
--- a/nginx/config.go
+++ b/nginx/config.go
@@ -16,6 +16,13 @@ events {
 }
 
 http {
+	# basic settings
+	vhost_traffic_status_zone;
+
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+
 	# The timeout value must be greater than the front facing load balancers timeout value.
 	# Default is the deis recommended timeout value for ELB - 1200 seconds + 100s extra.
 	keepalive_timeout {{ $routerConfig.DefaultTimeout }}s;


### PR DESCRIPTION
This PR continues the march toward feature parity.  ~~WIP, because it will need a rebase and doc updates after #27 is merged.~~

Note the "basic settings" are inherited directly from the v1.x router.