### PR TITLE
feat(router): add gzip support (option 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,14 @@ Note that although the annotation containing router configuration for each of th
 | deis-router          | defaultTimeout   | `integer`  | 1300          | Default timeout value in seconds.  Should be greater than the front-facing load balancer's timeout value. |
 | deis-router          | serverNameHashMaxSize | `integer` | `512`     | nginx `server_names_hash_max_size` setting. |
 | deis-router          | serverNameHashBucketSize | `integer` | 64     | nginx `server_names_hash_bucket_size` setting. |
+| deis-router          | gzipConfig             | `GzipConfig`  | Described by following lines.        | Set to `null` to disable gzip entirely. |
+| deis-router          | gzipConfig.compLevel   | `integer` | `5`        | nginx `gzip_comp_level` setting. |
+| deis-router          | gzipConfig.disable     | `string`  | `msie6`    | nginx `gzip_disable` setting. |
+| deis-router          | gzipConfig.httpVersion | `string`  | `1.1`      | nginx `gzip_http_version` setting. |
+| deis-router          | gzipConfig.minLength   | `integer` | `256`      | nginx `gzip_min_length` setting. |
+| deis-router          | gzipConfig.proxied     | `string`  | `any`      | nginx `gzip_proxied` setting. |
+| deis-router          | gzipConfig.types       | `string`  | `application/atom+xml application/javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component` | nginx `gzip_types` setting. |
+| deis-router          | gzipConfig.vary        | `string`  | `on`       | nginx `gzip_vary` setting. |
 | deis-router          | domain           | `string`   | N/A           | This defines the router's default domain.  Any domains added to a routable application _not_ containing the `.` character will be assumed to be subdomains of this default domain.  Thus, for example, a default domain of `example.com` coupled with a routable app counting `foo` among its domains will result in router configuration that routes traffic for `foo.example.com` to that application. |
 | deis-router          | useProxyProtocol | `boolean`  | `false`       | PROXY is a simple protocol supported by nginx, HAProxy, Amazon ELB, and others.  It provides a method to obtain information about a request's originating IP address from an external (to Kubernetes) load balancer in front of the router.  Enabling this option allows the router to select the originating IP from the HTTP `X-Forwarded-For` header. |
 | deis-builder         | connectTimeout   | `integer`  | `10000`       | `proxy_connect_timeout` (in milliseconds). |

--- a/model/model.go
+++ b/model/model.go
@@ -14,13 +14,14 @@ import (
 
 // RouterConfig is the primary type used to encapsulate all router configuration.
 type RouterConfig struct {
-	WorkerProcesses          string `json:"workerProcesses"`
-	MaxWorkerConnections     int    `json:"maxWorkerConnections"`
-	DefaultTimeout           int    `json:"defaultTimeout"`
-	ServerNameHashMaxSize    int    `json:"serverNameHashMaxSize"`
-	ServerNameHashBucketSize int    `json:"serverNameHashBucketSize"`
-	Domain                   string `json:"domain"`
-	UseProxyProtocol         bool   `json:"useProxyProtocol"`
+	WorkerProcesses          string      `json:"workerProcesses"`
+	MaxWorkerConnections     int         `json:"maxWorkerConnections"`
+	DefaultTimeout           int         `json:"defaultTimeout"`
+	ServerNameHashMaxSize    int         `json:"serverNameHashMaxSize"`
+	ServerNameHashBucketSize int         `json:"serverNameHashBucketSize"`
+	GzipConfig               *GzipConfig `json:"gzipConfig"`
+	Domain                   string      `json:"domain"`
+	UseProxyProtocol         bool        `json:"useProxyProtocol"`
 	AppConfigs               []*AppConfig
 	BuilderConfig            *BuilderConfig
 }
@@ -32,7 +33,31 @@ func newRouterConfig() *RouterConfig {
 		DefaultTimeout:           1300,
 		ServerNameHashMaxSize:    512,
 		ServerNameHashBucketSize: 64,
+		GzipConfig:               newGzipConfig(),
 		UseProxyProtocol:         false,
+	}
+}
+
+// GzipConfig encapsulates gzip configuration.
+type GzipConfig struct {
+	CompLevel   int    `json:"compLevel"`
+	Disable     string `json:"disable"`
+	HTTPVersion string `json:"httpVersion"`
+	MinLength   int    `json:"minLength"`
+	Proxied     string `json:"proxied"`
+	Types       string `json:"types"`
+	Vary        string `json:"vary"`
+}
+
+func newGzipConfig() *GzipConfig {
+	return &GzipConfig{
+		CompLevel:   5,
+		Disable:     "msie6",
+		HTTPVersion: "1.1",
+		MinLength:   256,
+		Proxied:     "any",
+		Types:       "application/atom+xml application/javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component",
+		Vary:        "on",
 	}
 }
 

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -34,6 +34,15 @@ http {
 	server_names_hash_max_size {{ $routerConfig.ServerNameHashMaxSize }};
 	server_names_hash_bucket_size {{ $routerConfig.ServerNameHashBucketSize }};
 
+	{{ if $routerConfig.GzipConfig }}{{ $gzipConfig := $routerConfig.GzipConfig }}gzip on;
+	gzip_comp_level {{ $gzipConfig.CompLevel }};
+	gzip_disable {{ $gzipConfig.Disable }};
+	gzip_http_version {{ $gzipConfig.HTTPVersion }};
+	gzip_min_length {{ $gzipConfig.MinLength }};
+	gzip_types {{ $gzipConfig.Types }};
+	gzip_proxied {{ $gzipConfig.Proxied }};
+	gzip_vary {{ $gzipConfig.Vary }};{{ end }}
+
 	log_format upstreaminfo '[$time_local] - {{ if $routerConfig.UseProxyProtocol }}$proxy_protocol_addr{{ else }}$remote_addr{{ end }} - $remote_user - $status - "$request" - $bytes_sent - "$http_referer" - "$http_user_agent" - "$server_name" - $upstream_addr - $http_host - $upstream_response_time - $request_time';
 
 	access_log /opt/nginx/logs/access.log upstreaminfo;


### PR DESCRIPTION
Alternative implementation of #35.  Ping @helgi: this drops the extra `useGzip` config option in favor of operators nulling out the `gzipConfig` if they want to disable it entirely.  lmk what you think.