### PR TITLE
chore(router): move pid to be consistent with v1.x

### DIFF
--- a/nginx/config.go
+++ b/nginx/config.go
@@ -10,7 +10,7 @@ import (
 const (
 	confTemplate = `{{ $routerConfig := . }}user nginx;
 daemon off;
-
+pid /run/nginx.pid;
 worker_processes {{ $routerConfig.WorkerProcesses }};
 
 events {


### PR DESCRIPTION
This is probably unnecessary, but it makes us more similar to v1.x's router.