### PR TITLE
feat(router): add router healthchecks

### DIFF
--- a/manifests/deis-router-rc.yaml
+++ b/manifests/deis-router-rc.yaml
@@ -36,3 +36,5 @@ spec:
           hostPort: 443
         - containerPort: 2222
           hostPort: 2222
+        - containerPort: 9090
+          hostPort: 9090


### PR DESCRIPTION
It would actually be nice to proxy the router healthchecks through to the kube-proxy-- which must also be functioning for the router to successfully route traffic, but if we want to run in any k8s cluster, there's really no guarantee that k8s components are configured to respond to health checks, as that is configurable.