### PR TITLE
feat(router): make platform domain optional

### DIFF
--- a/manifests/deis-router-rc.yaml
+++ b/manifests/deis-router-rc.yaml
@@ -8,7 +8,6 @@ metadata:
   annotations:
     deis.io/routerConfig: |
       {
-        "domain": "example.com",
         "useProxyProtocol": false
       }
 spec:

--- a/model/model.go
+++ b/model/model.go
@@ -225,10 +225,12 @@ func buildAppConfig(kubeClient *client.Client, service api.Service, routerConfig
 	if err != nil {
 		return nil, err
 	}
-	if routerConfig.Domain != "" {
-		for i, domain := range appConfig.Domains {
-			if !strings.Contains(domain, ".") {
+	for i, domain := range appConfig.Domains {
+		if !strings.Contains(domain, ".") {
+			if routerConfig.Domain != "" {
 				appConfig.Domains[i] = fmt.Sprintf("%s.%s", domain, routerConfig.Domain)
+			} else {
+				appConfig.Domains[i] = fmt.Sprintf("~^%s\\.(?<domain>.+)$", domain)
 			}
 		}
 	}


### PR DESCRIPTION
When a domain is not present in the routerConfig, we revert back to
a wildcard platform domain so users can make the platform domain
anything they wish.

Once this is merged, we can then remove the `domain` argument from the deis chart and move the router configuration in the docs somewhere else. This makes us compatible with the v1 router's routing behaviour.