### PR TITLE
doc(router): Update docs for accuracy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ dev-registry: check-docker
 	@docker inspect registry >/dev/null 2>&1 && docker start registry || docker run --restart="always" -d -p 5000:5000 --name registry registry:0.9.1
 	@echo
 	@echo "To use a local registry for Deis development:"
-	@echo "    export DEIS_REGISTRY=`docker-machine ip $$(docker-machine active 2>/dev/null) 2>/dev/null || echo $(HOST_IPADDR) `:5000"
+	@echo "    export DEIS_REGISTRY=`docker-machine ip $$(docker-machine active 2>/dev/null) 2>/dev/null || echo $(HOST_IPADDR) `:5000/"
 
 # Containerized dependency resolution
 bootstrap: check-docker

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This will produce output containing further instructions such as:
 59ba57a3628fe04016634760e039a3202036d5db984f6de96ea8876a7ba8a945
 
 To use a local registry for Deis development:
-    export DEIS_REGISTRY=192.168.99.102:5000
+    export DEIS_REGISTRY=192.168.99.102:5000/
 ```
 
 Following those instructions will make your local registry usable by the various `make` targets mentioned in following sections.
@@ -48,12 +48,9 @@ Following those instructions will make your local registry usable by the various
 If you do not want to run your own local registry or if the Kubernetes cluster you will be deploying to is remote, then you can easily make use of a public registry such as [hub.docker.com](http://hub.docker.com), provided you have an account.  To do so:
 
 ```
-$ export DEIS_REGISTRY=registry.hub.docker.com
-$ export IMAGE_PREFIX=your-username/
+$ export DEIS_REGISTRY=registry.hub.docker.com/
+$ export IMAGE_PREFIX=your-username
 ```
-
-__Do not miss the trailing slash in the `IMAGE_PREFIX`!__
-
 
 ### If I can `make` it there, I'll `make` it anywhere...
 


### PR DESCRIPTION
These are minor doc updates to reflect that the registry _should_ end with a trailing slash whilst the image prefix should not.  That was changed a while ago and docs were not updated accordingly at that time.