### PR TITLE
Remove unused config and modules

### DIFF
--- a/nginx/config.go
+++ b/nginx/config.go
@@ -21,8 +21,6 @@ events {
 
 http {
 	# basic settings
-	vhost_traffic_status_zone;
-
 	sendfile on;
 	tcp_nopush on;
 	tcp_nodelay on;

--- a/rootfs/bin/build
+++ b/rootfs/bin/build
@@ -3,10 +3,6 @@
 set -eof pipefail
 
 export NGINX_VERSION=1.9.6
-export NAXSI_VERSION=0d53a64ed856e694fcb4038748c8cf6d5551a603
-export NDK_VERSION=0.2.19
-export VTS_VERSION=22c51e201a550bb94e96239fef541347beb4eeca
-export SETMISC_VERSION=0.29
 
 export BUILD_PATH=/tmp/build
 
@@ -36,19 +32,6 @@ apk add --update-cache \
 get_src ed501fc6d0eff9d3bc1049cc1ba3a3ac8c602de046acb2a4c108392bbfa865ea \
         "http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
 
-get_src 128b56873eedbd3f240dc0f88a8b260d791321db92f14ba2fc5c49fc5307e04d \
-        "https://github.com/nbs-system/naxsi/archive/$NAXSI_VERSION.tar.gz"
-
-get_src 501f299abdb81b992a980bda182e5de5a4b2b3e275fbf72ee34dd7ae84c4b679 \
-        "https://github.com/simpl/ngx_devel_kit/archive/v$NDK_VERSION.tar.gz"
-
-get_src 8d280fc083420afb41dbe10df9a8ceec98f1d391bd2caa42ebae67d5bc9295d8 \
-        "https://github.com/openresty/set-misc-nginx-module/archive/v$SETMISC_VERSION.tar.gz"
-
-# replace with a release instead a commit once e06a618e5780b4b94b21cab37d61820dcd3bb585 is contained in one.
-get_src 47340cf0c711b10a0231fca9264d73ea791ff8420b823b0295ae3df2d968a205 \
-        "https://github.com/vozlt/nginx-module-vts/archive/$VTS_VERSION.tar.gz"
-
 # build nginx
 cd "$BUILD_PATH/nginx-$NGINX_VERSION"
 
@@ -71,10 +54,6 @@ cd "$BUILD_PATH/nginx-$NGINX_VERSION"
   --with-mail \
   --with-mail_ssl_module \
   --with-stream \
-  --add-module="$BUILD_PATH/naxsi-$NAXSI_VERSION/naxsi_src" \
-  --add-module="$BUILD_PATH/ngx_devel_kit-$NDK_VERSION" \
-  --add-module="$BUILD_PATH/set-misc-nginx-module-$SETMISC_VERSION" \
-  --add-module="$BUILD_PATH/nginx-module-vts-$VTS_VERSION" \
   && make && make install
 
 rm -rf "$BUILD_PATH"


### PR DESCRIPTION
This PR removes the `vhost_traffic_status_zone` directive.  That is part of the "virtual host traffic status module," which was only ever used for the sake of a status page that's been consciously omitted from v2 for security reasons.

With that directive gone, there are a total of 4 unused Nginx modules that this PR also removes.