### PR TITLE
Edit code and docs for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ _Note that Kubernetes annotation maps are all of Go type `map[string]string`.  A
 | deis-router | router.deis.io/bodySize | `"1"`| nginx `client_max_body_size` setting (in megabytes). |
 | deis-router | router.deis.io/proxyRealIpCidr | `"10.0.0.0/8"` | nginx `set_real_ip_from` setting.  Defines trusted addresses that are known to send correct replacement addresses. |
 | deis-router | router.deis.io/errorLogLevel | `"error"` | Log level used in the nginx `error_log` setting (valid values are: `debug`, `info`, `notice`, `warn`, `error`, `crit`, `alert`, and `emerg`). |
-| deis-router | router.deis.io/domain | N/A | This defines the router's default domain.  Any domains added to a routable application _not_ containing the `.` character will be assumed to be subdomains of this default domain.  Thus, for example, a default domain of `example.com` coupled with a routable app counting `foo` among its domains will result in router configuration that routes traffic for `foo.example.com` to that application. |
+| deis-router | router.deis.io/defaultDomain | N/A | This defines the router's default domain.  Any domains added to a routable application _not_ containing the `.` character will be assumed to be subdomains of this default domain.  Thus, for example, a default domain of `example.com` coupled with a routable app counting `foo` among its domains will result in router configuration that routes traffic for `foo.example.com` to that application. |
 | deis-router | router.deis.io/useProxyProtocol | `"false"` | PROXY is a simple protocol supported by nginx, HAProxy, Amazon ELB, and others.  It provides a method to obtain information about a request's originating IP address from an external (to Kubernetes) load balancer in front of the router.  Enabling this option allows the router to select the originating IP from the HTTP `X-Forwarded-For` header. |
 | deis-router | router.deis.io/enforceWhitelists | `"false"` | Whether to honor application-level IP / CIDR whitelists. |
 | deis-builder | router.deis.io/connectTimeout | `"10"` | nginx `proxy_connect_timeout` setting (in seconds). |
@@ -315,20 +315,20 @@ data:
   key: MT1...MRp=
 ```
 
-#### Wildcard platform certificate
+#### Default certificate
 
-A wildcard certificate may be supplied in the manner described above and can be used to provide a secure virtual host (in addition to the insecure virtual host) for _every_ "domain" of a routable service that is not a fully-qualified domain name.
+A wildcard certificate may be supplied in the manner described above and can be used as a default certificate to provide a secure virtual host (in addition to the insecure virtual host) for _every_ "domain" of a routable service that is not a fully-qualified domain name.
 
-For instance, if a routable service exists having a "domain" `frozen-wookie` and the platform domain is `example.com`, a supplied wildcard certificate for `*.example.com` will be used to secure a `frozen-wookie.example.com` virtual host.  Similarly, if no platform domain is defined, the supplied wildcard certificate will be used to secure a virtual host matching the expression `~^frozen-wookie\.(?<domain>.+)$`.  (The latter is almost certainly guaranteed to result in certificate warnings in an end user's browser, so it is advisable to always define the platform domain.)
+For instance, if a routable service exists having a "domain" `frozen-wookie` and the router's default domain is `example.com`, a supplied wildcard certificate for `*.example.com` will be used to secure a `frozen-wookie.example.com` virtual host.  Similarly, if no default domain is defined, the supplied wildcard certificate will be used to secure a virtual host matching the expression `~^frozen-wookie\.(?<domain>.+)$`.  (The latter is almost certainly guaranteed to result in certificate warnings in an end user's browser, so it is advisable to always define the router's default domain.)
 
 If the same routable service also had a domain `www.frozen-wookie.com`, the `*.example.com` wildcard certificate plays no role in securing the `www.frozen-wookie.com` virtual host.
 
-##### Wildcard platform certificate example
+##### Default certificate example
 
 Here is an example of a Kubernetes secret bearing a wildcard certificate for use by the router.  The following criteria must be met:
 
 * Namespace must be the same namespace as the router
-* Name must be `deis-router-cert`
+* Name must be `deis-router-default-cert`
 * Certificate must be supplied as the value of the key `cert`
 * Certificate private key must be supplied as the value of the key `key`
 * Both the certificate and private key must be base64 encoded
@@ -339,7 +339,7 @@ For example:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: deis-router-cert
+  name: deis-router-default-cert
   namespace: deis
 type: Opaque
 data:

--- a/manifests/examples.yaml
+++ b/manifests/examples.yaml
@@ -65,7 +65,7 @@ metadata:
     routable: "true"
     app: apache
   annotations:
-    # Demonstrates a subdomain of the platform's domain as well as a custom domain
+    # Demonstrates a subdomain of the router's default domain as well as a fully-qualified domain name
     router.deis.io/domains: apache,httpd.example.com
 spec:
   ports:

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -64,11 +64,11 @@ http {
 	# Default server handles requests for unmapped hostnames, including healthchecks
 	server {
 		listen 80 default_server reuseport{{ if $routerConfig.UseProxyProtocol }} proxy_protocol{{ end }};
-		{{ if $routerConfig.PlatformCertificate }}
+		{{ if $routerConfig.DefaultCertificate }}
 		listen 443 default_server ssl{{ if $routerConfig.UseProxyProtocol }} proxy_protocol{{ end }};
 		ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-		ssl_certificate /opt/nginx/ssl/platform.crt;
-		ssl_certificate_key /opt/nginx/ssl/platform.key;
+		ssl_certificate /opt/nginx/ssl/default.crt;
+		ssl_certificate_key /opt/nginx/ssl/default.key;
 		{{ end }}
 		server_name _;
 		location ~ ^/healthz/?$ {
@@ -97,7 +97,7 @@ http {
 
 	{{range $appConfig := $routerConfig.AppConfigs}}{{range $domain := $appConfig.Domains}}server {
 		listen 80{{ if $routerConfig.UseProxyProtocol }} proxy_protocol{{ end }};
-		server_name {{ if contains "." $domain }}{{ $domain }}{{ else if ne $routerConfig.Domain "" }}{{ $domain }}.{{ $routerConfig.Domain }}{{ else }}~^{{ $domain }}\.(?<domain>.+)${{ end }};
+		server_name {{ if contains "." $domain }}{{ $domain }}{{ else if ne $routerConfig.DefaultDomain "" }}{{ $domain }}.{{ $routerConfig.DefaultDomain }}{{ else }}~^{{ $domain }}\.(?<domain>.+)${{ end }};
 		server_name_in_redirect off;
 		port_in_redirect off;
 
@@ -142,8 +142,8 @@ http {
 )
 
 func WriteCerts(routerConfig *model.RouterConfig, sslPath string) error {
-	if routerConfig.PlatformCertificate != nil {
-		err := writeCert("platform", routerConfig.PlatformCertificate, sslPath)
+	if routerConfig.DefaultCertificate != nil {
+		err := writeCert("default", routerConfig.DefaultCertificate, sslPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This is a bundle of minor code and doc edits intended to make router a bit easier to understand on both fronts.

I've done away with the concept of "platform domain."  It's technically still there, but the old moniker didn't make much sense.  On account of the fact that the router can be used without the rest of Deis, "what platform?" might, at times, have been a relevant question.  This has been replaced with "default domain."

Similarly, I've done away with the concept of "custom domains."  _What does that even mean?_  From a deis/workflow perspective, it makes a lot of sense, but once again, from the router's perspective, loosely coupled to workflow as it is, this isn't an especially meaningful concept.

What it all boils down to, quite simply, is that for each routable service, router looks at a list of "domains."  Those might be fully-qualified domain names (which we would have called "custom" before) or simple names not containing dots which are subdomains of the "default domain" (which was "platform domain" before).

IMO, the greater precision of language introduced by this PR makes router a bit more grokable.

WIP only because this is blocked by #78, which should be merged first.