### PR TITLE
feat(router): Implement various ssl-related options

### DIFF
--- a/router.go
+++ b/router.go
@@ -32,7 +32,12 @@ func main() {
 		log.Println("INFO: Router configuration has changed in k8s.")
 		err = nginx.WriteCerts(routerConfig, "/opt/nginx/ssl")
 		if err != nil {
-			log.Printf("Failed to write certs; continuing with existing certs and configuration: %v", err)
+			log.Printf("Failed to write certs; continuing with existing certs, dhparam, and configuration: %v", err)
+			continue
+		}
+		err = nginx.WriteDHParam(routerConfig, "/opt/nginx/ssl")
+		if err != nil {
+			log.Printf("Failed to write dhparam; continuing with existing dhparam and configuration: %v", err)
 			continue
 		}
 		err = nginx.WriteConfig(routerConfig, "/opt/nginx/conf/nginx.conf")


### PR DESCRIPTION
Fixes #89 

~~This PR is the final bit to establish router feature parity with v1.x (minus the naxsi firewall) with v1.x.~~  This allows various SSL-related options to be fine-tuned.

Some things to note:

1.  Although this provides feature parity, defaults for some options have changed in order to earn a better grade from [Qualys SSL Labs](https://www.ssllabs.com/ssltest/analyze.html).  Just adding an appropriate cert to an app (or a wildcard cert to the platform), you can earn an A.  With some minimal tuning, an A+ is possible.

2.  There is some minor rework of things committed in #84.  The option to enforce the use of HTTPS and HSTS config options introduced there seemed like they should be pulled under the new `SSLConfig` object introduced by this PR.

3.  I intend to take a pass through _all_ configuration options (these an others) to see in what ways we can clean them up-- make them more natural to use, possibly add validation of option values, and make them less nginx-specific where possible (and implement "nginx" extensions where not possible; see #36). 