### PR TITLE
Config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,9 @@ _Note that Kubernetes annotation maps are all of Go type `map[string]string`.  A
 |-----------|------------|---------------|-------------|
 | deis-router | router.deis.io/workerProcesses | `"auto"` (number of CPU cores) | Number of worker processes to start. |
 | deis-router | router.deis.io/workerConnections| `"768"` | Maximum number of simultaneous connections that can be opened by a worker process. |
-| deis-router | router.deis.io/defaultTimeout | `"1300"` | Default timeout value in seconds.  Should be greater than the front-facing load balancer's timeout value. |
-| deis-router | router.deis.io/serverNameHashMaxSize | `"512"` | nginx `server_names_hash_max_size` setting. |
-| deis-router | router.deis.io/serverNameHashBucketSize | `"64"` | nginx `server_names_hash_bucket_size` setting. |
+| deis-router | router.deis.io/defaultTimeout | `"1300s"` | Default timeout value expressed in units `ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `y`.  Should be longer than the front-facing load balancer's idle timeout. |
+| deis-router | router.deis.io/serverNameHashMaxSize | `"512"` | nginx `server_names_hash_max_size` setting expressed in bytes (no suffix), kilobytes (suffixes `k` and `K`), or megabytes (suffixes `m` and `M`). |
+| deis-router | router.deis.io/serverNameHashBucketSize | `"64"` | nginx `server_names_hash_bucket_size` setting expressed in bytes (no suffix), kilobytes (suffixes `k` and `K`), or megabytes (suffixes `m` and `M`). |
 | deis-router | router.deis.io/gzip.enabled | `"true"` | Whether to enable gzip compression. |
 | deis-router | router.deis.io/gzip.compLevel | `"5"` | nginx `gzip_comp_level` setting. |
 | deis-router | router.deis.io/gzip.disable | `"msie6"` | nginx `gzip_disable` setting. |
@@ -225,7 +225,7 @@ _Note that Kubernetes annotation maps are all of Go type `map[string]string`.  A
 | deis-router | router.deis.io/gzip.proxied | `"any"` | nginx `gzip_proxied` setting. |
 | deis-router | router.deis.io/gzip.types | `"application/atom+xml application/javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component"` | nginx `gzip_types` setting. |
 | deis-router | router.deis.io/gzip.vary | `"on"` | nginx `gzip_vary` setting. |
-| deis-router | router.deis.io/bodySize | `"1"`| nginx `client_max_body_size` setting (in megabytes). |
+| deis-router | router.deis.io/bodySize | `"1m"`| nginx `client_max_body_size` setting expressed in bytes (no suffix), kilobytes (suffixes `k` and `K`), or megabytes (suffixes `m` and `M`). |
 | deis-router | router.deis.io/proxyRealIpCidr | `"10.0.0.0/8"` | nginx `set_real_ip_from` setting.  Defines trusted addresses that are known to send correct replacement addresses. |
 | deis-router | router.deis.io/errorLogLevel | `"error"` | Log level used in the nginx `error_log` setting (valid values are: `debug`, `info`, `notice`, `warn`, `error`, `crit`, `alert`, and `emerg`). |
 | deis-router | router.deis.io/defaultDomain | N/A | This defines the router's default domain.  Any domains added to a routable application _not_ containing the `.` character will be assumed to be subdomains of this default domain.  Thus, for example, a default domain of `example.com` coupled with a routable app counting `foo` among its domains will result in router configuration that routes traffic for `foo.example.com` to that application. |
@@ -235,19 +235,19 @@ _Note that Kubernetes annotation maps are all of Go type `map[string]string`.  A
 | deis-router | router.deis.io/ssl.protocols | `"TLSv1 TLSv1.1 TLSv1.2"` | nginx `ssl_protocols` setting. |
 | deis-router | router.deis.io/ssl.ciphers | `""` | nginx `ssl_ciphers`.  If the value is the empty string, OpenSSL's default ciphers are used.  In _all_ cases, server side cipher preferences (order matter) are used. |
 | deis-router | router.deis.io/ssl.sessionCache | `""` | nginx `ssl_session_cache` setting. |
-| deis-router | router.deis.io/ssl.sessionTimeout | `"10"` | nginx `ssl_session_timeout` setting (in minutes).  |
-| deis-router | router.deis.io/ssl.sessionTickets | `"on"` | nginx `ssl_session_tickets` setting. |
-| deis-router | router.deis.io/ssl.bufferSize | `"4"` | nginx `ssl_buffer_size` setting (in kilobytes). |
+| deis-router | router.deis.io/ssl.sessionTimeout | `"10m"` | nginx `ssl_session_timeout` expressed in units `ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `y`. |
+| deis-router | router.deis.io/ssl.useSessionTickets | `"true"` | Whether to use [TLS session tickets](http://tools.ietf.org/html/rfc5077) for session resumption without server-side state. |
+| deis-router | router.deis.io/ssl.bufferSize | `"4k"` | nginx `ssl_buffer_size` setting expressed in bytes (no suffix), kilobytes (suffixes `k` and `K`), or megabytes (suffixes `m` and `M`). |
 | deis-router | router.deis.io/ssl.hsts.enabled | `"false"` | Whether to use HTTP Strict Transport Security. |
 | deis-router | router.deis.io/ssl.hsts.maxAge | `"10886400"` | Maximum number of seconds user agents should observe HSTS rewrites. |
 | deis-router | router.deis.io/ssl.hsts.includeSubDomains | `"false"` | Whether to enforce HSTS for subsequent requests to all subdomains of the original request. |
 | deis-router | router.deis.io/ssl.hsts.preload | `"false"` | Whether to allow the domain to be included in the HSTS preload list. |
-| deis-builder | router.deis.io/connectTimeout | `"10"` | nginx `proxy_connect_timeout` setting (in seconds). |
-| deis-builder | router.deis.io/tcpTimeout | `"1200"` | nginx `proxy_timeout` setting (in seconds). |
+| deis-builder | router.deis.io/connectTimeout | `"10s"` | nginx `proxy_connect_timeout` setting expressed in units `ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `y`. |
+| deis-builder | router.deis.io/tcpTimeout | `"1200s"` | nginx `proxy_timeout` setting expressed in units `ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `y`. |
 | routable application | router.deis.io/domains | N/A | Comma-delimited list of domains for which traffic should be routed to the application.  These may be fully qualified (e.g. `foo.example.com`) or, if not containing any `.` character, will be considered subdomains of the router's domain, if that is defined. |
 | routable application | router.deis.io/whitelist | N/A | Comma-delimited list of addresses permitted to access the application (using IP or CIDR notation).  Requests from all other addresses are denied. |
-| routable application | router.deis.io/connectTimeout | `"30"` | nginx `proxy_connect_timeout` setting (in seconds). |
-| routable application | router.deis.io/tcpTimeout | router's `defaultTimeout` | nginx `proxy_send_timeout` and `proxy_read_timeout` settings (in seconds). |
+| routable application | router.deis.io/connectTimeout | `"30s"` | nginx `proxy_connect_timeout` setting expressed in units `ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `y`. |
+| routable application | router.deis.io/tcpTimeout | router's `defaultTimeout` | nginx `proxy_send_timeout` and `proxy_read_timeout` settings expressed in units `ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `y`. |
 
 #### Annotations by example
 

--- a/model/model.go
+++ b/model/model.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	modelerKeyPrefix     string = "router.deis.io"
-	modelerFieldTag      string = "router"
+	modelerFieldTag      string = "key"
 	modelerConstraintTag string = "constraint"
 )
 
@@ -26,19 +26,19 @@ var (
 
 // RouterConfig is the primary type used to encapsulate all router configuration.
 type RouterConfig struct {
-	WorkerProcesses          string      `router:"workerProcesses"`
-	MaxWorkerConnections     int         `router:"maxWorkerConnections"`
-	DefaultTimeout           int         `router:"defaultTimeout"`
-	ServerNameHashMaxSize    int         `router:"serverNameHashMaxSize"`
-	ServerNameHashBucketSize int         `router:"serverNameHashBucketSize"`
-	GzipConfig               *GzipConfig `router:"gzip"`
-	BodySize                 int         `router:"bodySize"`
-	ProxyRealIPCIDR          string      `router:"proxyRealIpCidr"`
-	ErrorLogLevel            string      `router:"errorLogLevel"`
-	DefaultDomain            string      `router:"defaultDomain"`
-	UseProxyProtocol         bool        `router:"useProxyProtocol"`
-	EnforceWhitelists        bool        `router:"enforceWhitelists"`
-	SSLConfig                *SSLConfig  `router:"ssl"`
+	WorkerProcesses          string      `key:"workerProcesses" constraint:"^(auto|[1-9]\\d*)$"`
+	MaxWorkerConnections     string      `key:"maxWorkerConnections" constraint:"^[1-9]\\d*$"`
+	DefaultTimeout           string      `key:"defaultTimeout" constraint:"^[1-9]\\d*(ms|[smhdwMy])?$"`
+	ServerNameHashMaxSize    string      `key:"serverNameHashMaxSize" constraint:"^[1-9]\\d*[kKmM]?$"`
+	ServerNameHashBucketSize string      `key:"serverNameHashBucketSize" constraint:"^[1-9]\\d*[kKmM]?$"`
+	GzipConfig               *GzipConfig `key:"gzip"`
+	BodySize                 string      `key:"bodySize" constraint:"^[1-9]\\d*[kKmM]?$"`
+	ProxyRealIPCIDR          string      `key:"proxyRealIpCidr" constraint:"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$"`
+	ErrorLogLevel            string      `key:"errorLogLevel" constraint:"^(info|notice|warn|error|crit|alert|emerg)$"`
+	DefaultDomain            string      `key:"defaultDomain" constraint:"(?i)^([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,}$"`
+	UseProxyProtocol         bool        `key:"useProxyProtocol" constraint:"(?i)^(true|false)$"`
+	EnforceWhitelists        bool        `key:"enforceWhitelists" constraint:"(?i)^(true|false)$"`
+	SSLConfig                *SSLConfig  `key:"ssl"`
 	AppConfigs               []*AppConfig
 	BuilderConfig            *BuilderConfig
 	DefaultCertificate       *Certificate
@@ -47,12 +47,12 @@ type RouterConfig struct {
 func newRouterConfig() *RouterConfig {
 	return &RouterConfig{
 		WorkerProcesses:          "auto",
-		MaxWorkerConnections:     768,
-		DefaultTimeout:           1300,
-		ServerNameHashMaxSize:    512,
-		ServerNameHashBucketSize: 64,
+		MaxWorkerConnections:     "768",
+		DefaultTimeout:           "1300s",
+		ServerNameHashMaxSize:    "512",
+		ServerNameHashBucketSize: "64",
 		GzipConfig:               newGzipConfig(),
-		BodySize:                 1,
+		BodySize:                 "1m",
 		ProxyRealIPCIDR:          "10.0.0.0/8",
 		ErrorLogLevel:            "error",
 		UseProxyProtocol:         false,
@@ -63,23 +63,23 @@ func newRouterConfig() *RouterConfig {
 
 // GzipConfig encapsulates gzip configuration.
 type GzipConfig struct {
-	Enabled     bool   `router:"enabled"`
-	CompLevel   int    `router:"compLevel"`
-	Disable     string `router:"disable"`
-	HTTPVersion string `router:"httpVersion"`
-	MinLength   int    `router:"minLength"`
-	Proxied     string `router:"proxied"`
-	Types       string `router:"types"`
-	Vary        string `router:"vary"`
+	Enabled     bool   `key:"enabled" constraint:"(?i)^(true|false)$"`
+	CompLevel   string `key:"compLevel" constraint:"^[1-9]$"`
+	Disable     string `key:"disable"`
+	HTTPVersion string `key:"httpVersion" constraint:"^(1\\.0|1\\.1)$"`
+	MinLength   string `key:"minLength" constraint:"^\\d+$"`
+	Proxied     string `key:"proxied" constraint:"^((off|expired|no-cache|no-store|private|no_last_modified|no_etag|auth|any)\\s*)+$"`
+	Types       string `key:"types" constraint:"(?i)^([a-z\\d]+/[a-z\\d][a-z\\d+\\-\\.]*[a-z\\d]\\s*)+$"`
+	Vary        string `key:"vary" constraint:"^(on|off)$"`
 }
 
 func newGzipConfig() *GzipConfig {
 	return &GzipConfig{
 		Enabled:     true,
-		CompLevel:   5,
+		CompLevel:   "5",
 		Disable:     "msie6",
 		HTTPVersion: "1.1",
-		MinLength:   256,
+		MinLength:   "256",
 		Proxied:     "any",
 		Types:       "application/atom+xml application/javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component",
 		Vary:        "on",
@@ -88,17 +88,17 @@ func newGzipConfig() *GzipConfig {
 
 // AppConfig encapsulates the configuration for all routes to a single back end.
 type AppConfig struct {
-	Domains        []string `router:"domains"`
-	Whitelist      []string `router:"whitelist"`
-	ConnectTimeout int      `router:"connectTimeout"`
-	TCPTimeout     int      `router:"tcpTimeout"`
+	Domains        []string `key:"domains" constraint:"(?i)^((([a-z0-9]+(-[a-z0-9]+)*)|([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,})(\\s*,\\s*)?)+$"`
+	Whitelist      []string `key:"whitelist" constraint:"^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))?(\\s*,\\s*)?)+$"`
+	ConnectTimeout string   `key:"connectTimeout" constraint:"^[1-9]\\d*(ms|[smhdwMy])?$"`
+	TCPTimeout     string   `key:"tcpTimeout" constraint:"^[1-9]\\d*(ms|[smhdwMy])?$"`
 	ServiceIP      string
 	Certificates   map[string]*Certificate
 }
 
 func newAppConfig(routerConfig *RouterConfig) *AppConfig {
 	return &AppConfig{
-		ConnectTimeout: 30,
+		ConnectTimeout: "30s",
 		TCPTimeout:     routerConfig.DefaultTimeout,
 		Certificates:   make(map[string]*Certificate, 0),
 	}
@@ -106,15 +106,15 @@ func newAppConfig(routerConfig *RouterConfig) *AppConfig {
 
 // BuilderConfig encapsulates the configuration of the deis-builder-- if it's in use.
 type BuilderConfig struct {
-	ConnectTimeout int `router:"connectTimeout"`
-	TCPTimeout     int `router:"tcpTimeout"`
+	ConnectTimeout string `key:"connectTimeout" constraint:"^[1-9]\\d*(ms|[smhdwMy])?$"`
+	TCPTimeout     string `key:"tcpTimeout" constraint:"^[1-9]\\d*(ms|[smhdwMy])?$"`
 	ServiceIP      string
 }
 
 func newBuilderConfig() *BuilderConfig {
 	return &BuilderConfig{
-		ConnectTimeout: 10,
-		TCPTimeout:     1200,
+		ConnectTimeout: "10s",
+		TCPTimeout:     "1200s",
 	}
 }
 
@@ -133,34 +133,34 @@ func newCertificate(cert string, key string) *Certificate {
 
 // SSLConfig represents SSL-related configuration options.
 type SSLConfig struct {
-	Enforce        bool        `router:"enforce"`
-	Protocols      string      `router:"protocols"`
-	Ciphers        string      `router:"ciphers"`
-	SessionCache   string      `router:"sessionCache"`
-	SessionTimeout int         `router:"sessionTimeout"`
-	SessionTickets string      `router:"sessionTickets"`
-	BufferSize     int         `router:"bufferSize"`
-	HSTSConfig     *HSTSConfig `router:"hsts"`
-	DHParam        string
+	Enforce           bool        `key:"enforce" constraint:"(?i)^(true|false)$"`
+	Protocols         string      `key:"protocols" constraint:"^((SSLv2|SSLv3|TLSv1|TLSv1\\.1|TLSv1\\.2)\\s*)+$"`
+	Ciphers           string      `key:"ciphers" constraint:"^([A-Z][A-Z\\d-]+:?)*$"`
+	SessionCache      string      `key:"sessionCache" constraint:"^(off|none|((builtin(:[1-9]\\d*)?|shared:\\w+:[1-9]\\d*[kKmM]?)\\s*){1,2})$"`
+	SessionTimeout    string      `key:"sessionTimeout" constraint:"^[1-9]\\d*(ms|[smhdwMy])?$"`
+	UseSessionTickets bool        `key:"useSessionTickets" constraint:"(?i)^(true|false)$"`
+	BufferSize        string      `key:"bufferSize" constraint:"^[1-9]\\d*[kKmM]?$"`
+	HSTSConfig        *HSTSConfig `key:"hsts"`
+	DHParam           string
 }
 
 func newSSLConfig() *SSLConfig {
 	return &SSLConfig{
-		Enforce:        false,
-		Protocols:      "TLSv1 TLSv1.1 TLSv1.2",
-		SessionTimeout: 10,
-		SessionTickets: "on",
-		BufferSize:     4,
-		HSTSConfig:     newHSTSConfig(),
+		Enforce:           false,
+		Protocols:         "TLSv1 TLSv1.1 TLSv1.2",
+		SessionTimeout:    "10m",
+		UseSessionTickets: true,
+		BufferSize:        "4k",
+		HSTSConfig:        newHSTSConfig(),
 	}
 }
 
 // HSTSConfig represents configuration options having to do with HTTP Strict Transport Security.
 type HSTSConfig struct {
-	Enabled           bool `router:"enabled"`
-	MaxAge            int  `router:"maxAge"`
-	IncludeSubDomains bool `router:"includeSubDomains"`
-	Preload           bool `router:"preload"`
+	Enabled           bool `key:"enabled" constraint:"(?i)^(true|false)$"`
+	MaxAge            int  `key:"maxAge" constraint:"^[1-9]\\d*$"`
+	IncludeSubDomains bool `key:"includeSubDomains" constraint:"(?i)^(true|false)$"`
+	Preload           bool `key:"preload" constraint:"(?i)^(true|false)$"`
 }
 
 func newHSTSConfig() *HSTSConfig {

--- a/model/model.go
+++ b/model/model.go
@@ -13,6 +13,17 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 )
 
+const (
+	modelerKeyPrefix     string = "router.deis.io"
+	modelerFieldTag      string = "router"
+	modelerConstraintTag string = "constraint"
+)
+
+var (
+	namespace = utils.GetOpt("POD_NAMESPACE", "default")
+	modeler   = modelerUtility.NewModeler(modelerKeyPrefix, modelerFieldTag, modelerConstraintTag, true)
+)
+
 // RouterConfig is the primary type used to encapsulate all router configuration.
 type RouterConfig struct {
 	WorkerProcesses          string      `router:"workerProcesses"`
@@ -160,11 +171,6 @@ func newHSTSConfig() *HSTSConfig {
 		Preload:           false,
 	}
 }
-
-var (
-	namespace = utils.GetOpt("POD_NAMESPACE", "default")
-	modeler   = modelerUtility.NewModeler("router.deis.io", "router", "constraint", true)
-)
 
 // Build creates a RouterConfig configuration object by querying the k8s API for
 // relevant metadata concerning itself and all routable services.

--- a/model/model.go
+++ b/model/model.go
@@ -163,7 +163,7 @@ func newHSTSConfig() *HSTSConfig {
 
 var (
 	namespace = utils.GetOpt("POD_NAMESPACE", "default")
-	modeler   = modelerUtility.NewModeler("router.deis.io", "router")
+	modeler   = modelerUtility.NewModeler("router.deis.io", "router", "constraint", true)
 )
 
 // Build creates a RouterConfig configuration object by querying the k8s API for

--- a/model/model_validation_test.go
+++ b/model/model_validation_test.go
@@ -1,0 +1,354 @@
+package model
+
+import (
+	"reflect"
+	"testing"
+
+	modelerUtility "github.com/deis/router/utils/modeler"
+)
+
+var (
+	// We'll test the declarative constraints on model attributes using this modeler instead of the
+	// one defined in the non-test half of this package.  Why?  We want one that generates errors
+	// instead of merely outputting warnings.  That allows us to easily assert validation failures
+	// and also prevents us from clutter STDOUT with useless noise.
+	testModeler = modelerUtility.NewModeler("", modelerFieldTag, modelerConstraintTag, false)
+)
+
+func TestInvalidWorkerProcesses(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "WorkerProcesses", "workerProcesses", []string{"0", "-1", "foobar"})
+}
+
+func TestValidWorkerProcesses(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "WorkerProcesses", "workerProcesses", []string{"auto", "2", "10"})
+}
+
+func TestInvalidMaxWorkerConnections(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "MaxWorkerConnections", "maxWorkerConnections", []string{"0", "-1", "foobar"})
+}
+
+func TestValidMaxWorkerConnections(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "MaxWorkerConnections", "maxWorkerConnections", []string{"1", "2", "10"})
+}
+
+func TestInvalidDefaultTimeout(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "DefaultTimeout", "defaultTimeout", []string{"0", "-1", "foobar"})
+}
+
+func TestValidDefaultTimeout(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "DefaultTimeout", "defaultTimeout", []string{"1", "2", "10", "1ms", "2s", "10m"})
+}
+
+func TestInvalidServerNameHashMaxSize(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "ServerNameHashMaxSize", "serverNameHashMaxSize", []string{"0", "-1", "foobar"})
+}
+
+func TestValidServerNameHashMaxSize(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "ServerNameHashMaxSize", "serverNameHashMaxSize", []string{"1", "2", "20", "1k", "2k", "10m", "10M"})
+}
+
+func TestInvalidServerNameHashBucketSize(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "ServerNameHashBucketSize", "serverNameHashBucketSize", []string{"0", "-1", "foobar"})
+}
+
+func TestValidServerNameHashBucketSize(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "ServerNameHashBucketSize", "serverNameHashBucketSize", []string{"1", "2", "20", "1k", "2k", "10m", "10M"})
+}
+
+func TestInvalidBodySize(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "BodySize", "bodySize", []string{"0", "-1", "foobar"})
+}
+
+func TestValidBodySize(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "BodySize", "bodySize", []string{"1", "2", "20", "1k", "2k", "10m", "10M"})
+}
+
+func TestInvalidProxyRealIPCIDR(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "ProxyRealIPCIDR", "proxyRealIpCidr", []string{"0", "-1", "foobar"})
+}
+
+func TestValidProxyRealIPCIDR(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "ProxyRealIPCIDR", "proxyRealIpCidr", []string{"0.0.0.0/0", "10.0.0.0/16"})
+}
+
+func TestInvalidErrorLogLevel(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "ErrorLogLevel", "errorLogLevel", []string{"0", "-1", "foobar"})
+}
+
+func TestValidErrorLogLevel(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "ErrorLogLevel", "errorLogLevel", []string{"info", "notice", "warn"})
+}
+
+func TestInvalidDefaultDomain(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "DefaultDomain", "defaultDomain", []string{"0", "-1", "foobar", "foo_bar.com", "foobar.c"})
+}
+
+func TestValidDefaultDomain(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "DefaultDomain", "defaultDomain", []string{"foobar.com", "foo-bar.io"})
+}
+
+func TestInvalidUseProxyProtocol(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "UseProxyProtocol", "useProxyProtocol", []string{"0", "-1", "foobar"})
+}
+
+func TestValidUseProxyProtocol(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "UseProxyProtocol", "useProxyProtocol", []string{"true", "false", "TRUE", "FALSE"})
+}
+
+func TestInvalidEnforceWhitelists(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "EnforceWhitelists", "enforceWhitelists", []string{"0", "-1", "foobar"})
+}
+
+func TestValidEnforceWhitelists(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "EnforceWhitelists", "enforceWhitelists", []string{"true", "false", "TRUE", "FALSE"})
+}
+
+func TestInvalidGzipEnabled(t *testing.T) {
+	testInvalidValues(t, newTestGzipConfig, "Enabled", "enabled", []string{"0", "-1", "foobar"})
+}
+
+func TestValidGzipEnabled(t *testing.T) {
+	testValidValues(t, newTestGzipConfig, "Enabled", "enabled", []string{"true", "false", "TRUE", "FALSE"})
+}
+
+func TestInvalidGzipCompLevel(t *testing.T) {
+	testInvalidValues(t, newTestGzipConfig, "CompLevel", "compLevel", []string{"0", "-1", "foobar"})
+}
+
+func TestValidGzipCompLevel(t *testing.T) {
+	testValidValues(t, newTestGzipConfig, "CompLevel", "compLevel", []string{"1", "2", "3", "4"})
+}
+
+func TestInvalidGzipHTTPVersion(t *testing.T) {
+	testInvalidValues(t, newTestGzipConfig, "HTTPVersion", "httpVersion", []string{"0", "-1", "foobar"})
+}
+
+func TestValidGzipHTTPVersion(t *testing.T) {
+	testValidValues(t, newTestGzipConfig, "HTTPVersion", "httpVersion", []string{"1.0", "1.1"})
+}
+
+func TestInvalidGzipMinLength(t *testing.T) {
+	testInvalidValues(t, newTestGzipConfig, "MinLength", "minLength", []string{"-1", "foobar"})
+}
+
+func TestValidGzipMinLength(t *testing.T) {
+	testValidValues(t, newTestGzipConfig, "MinLength", "minLength", []string{"0", "1", "2", "20"})
+}
+
+func TestInvalidGzipProxied(t *testing.T) {
+	testInvalidValues(t, newTestGzipConfig, "Proxied", "proxied", []string{"0", "-1", "foobar"})
+}
+
+func TestValidGzipProxied(t *testing.T) {
+	testValidValues(t, newTestGzipConfig, "Proxied", "proxied", []string{"off", "expired", "no-cache", "no-store private no_etag"})
+}
+
+func TestInvalidGzipTypes(t *testing.T) {
+	testInvalidValues(t, newTestGzipConfig, "Types", "types", []string{"0", "-1", "foobar"})
+}
+
+func TestValidGzipTypes(t *testing.T) {
+	testValidValues(t, newTestGzipConfig, "Types", "types", []string{"application/json", "application/json application/text"})
+}
+
+func TestInvalidGzipVary(t *testing.T) {
+	testInvalidValues(t, newTestGzipConfig, "Vary", "vary", []string{"0", "-1", "foobar"})
+}
+
+func TestValidGzipVary(t *testing.T) {
+	testValidValues(t, newTestGzipConfig, "Vary", "vary", []string{"on", "off"})
+}
+
+func TestInvalidAppDomains(t *testing.T) {
+	testInvalidValues(t, newTestAppConfig, "Domains", "domains", []string{"-1", "foo_bar", "foobar.c", "foo bar"})
+}
+
+func TestValidAppDomains(t *testing.T) {
+	testValidValues(t, newTestAppConfig, "Domains", "domains", []string{"foobar", "foo-bar", "foobar.com", "foobar,foobar.com", "foobar, foobar.com"})
+}
+
+func TestInvalidAppWhitelist(t *testing.T) {
+	testInvalidValues(t, newTestAppConfig, "Whitelist", "whitelist", []string{"0", "-1", "foobar"})
+}
+
+func TestValidAppWhitelist(t *testing.T) {
+	testValidValues(t, newTestAppConfig, "Whitelist", "whitelist", []string{"1.2.3.4", "0.0.0.0/0", "1.2.3.4,0.0.0.0/0", "1.2.3.4, 0.0.0.0/0"})
+}
+
+func TestInvalidAppConnectTimeout(t *testing.T) {
+	testInvalidValues(t, newTestAppConfig, "ConnectTimeout", "connectTimeout", []string{"0", "-1", "foobar"})
+}
+
+func TestValidAppConnectTimeout(t *testing.T) {
+	testValidValues(t, newTestAppConfig, "ConnectTimeout", "connectTimeout", []string{"1", "2", "10", "1ms", "2s", "10m"})
+}
+
+func TestInvalidAppTCPTimeout(t *testing.T) {
+	testInvalidValues(t, newTestAppConfig, "TCPTimeout", "tcpTimeout", []string{"0", "-1", "foobar"})
+}
+
+func TestValidAppTCPTimeout(t *testing.T) {
+	testValidValues(t, newTestAppConfig, "TCPTimeout", "tcpTimeout", []string{"1", "2", "10", "1ms", "2s", "10m"})
+}
+
+func TestInvalidBuilderConnectTimeout(t *testing.T) {
+	testInvalidValues(t, newTestBuilderConfig, "ConnectTimeout", "connectTimeout", []string{"0", "-1", "foobar"})
+}
+
+func TestValidBuilderConnectTimeout(t *testing.T) {
+	testValidValues(t, newTestBuilderConfig, "ConnectTimeout", "connectTimeout", []string{"1", "2", "10", "1ms", "2s", "10m"})
+}
+
+func TestInvalidBuilderTCPTimeout(t *testing.T) {
+	testInvalidValues(t, newTestBuilderConfig, "TCPTimeout", "tcpTimeout", []string{"0", "-1", "foobar"})
+}
+
+func TestValidBuilderTCPTimeout(t *testing.T) {
+	testValidValues(t, newTestBuilderConfig, "TCPTimeout", "tcpTimeout", []string{"1", "2", "10", "1ms", "2s", "10m"})
+}
+
+func TestInvalidSSLEnforce(t *testing.T) {
+	testInvalidValues(t, newTestSSLConfig, "Enforce", "enforce", []string{"0", "-1", "foobar"})
+}
+
+func TestValidSSLEnforce(t *testing.T) {
+	testValidValues(t, newTestSSLConfig, "Enforce", "enforce", []string{"true", "false", "TRUE", "FALSE"})
+}
+
+func TestInvalidSSLProtocols(t *testing.T) {
+	testInvalidValues(t, newTestSSLConfig, "Protocols", "protocols", []string{"0", "-1", "foobar"})
+}
+
+func TestValidSSLProtocols(t *testing.T) {
+	testValidValues(t, newTestSSLConfig, "Protocols", "protocols", []string{"SSLv3", "TLSv1", "TLSv1 TLSv1.1"})
+}
+
+func TestInvalidSSLCiphers(t *testing.T) {
+	testInvalidValues(t, newTestSSLConfig, "Ciphers", "ciphers", []string{"0", "-1", "foobar"})
+}
+
+func TestValidSSLCiphers(t *testing.T) {
+	testValidValues(t, newTestSSLConfig, "Ciphers", "ciphers", []string{"DHE-RSA-AES256-SHA", "DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:AES256-SHA"})
+}
+
+func TestInvalidSSLSessionCache(t *testing.T) {
+	testInvalidValues(t, newTestSSLConfig, "SessionCache", "sessionCache", []string{"0", "-1", "foobar"})
+}
+
+func TestValidSSLSessionCache(t *testing.T) {
+	testValidValues(t, newTestSSLConfig, "SessionCache", "sessionCache", []string{"off", "none", "builtin", "builtin:1000", "builtin:1000 shared:SSL:16k"})
+}
+
+func TestInvalidSSLSessionTimeout(t *testing.T) {
+	testInvalidValues(t, newTestSSLConfig, "SessionTimeout", "sessionTimeout", []string{"0", "-1", "foobar"})
+}
+
+func TestValidSSLSessionTimeout(t *testing.T) {
+	testValidValues(t, newTestSSLConfig, "SessionTimeout", "sessionTimeout", []string{"1", "2", "10", "1ms", "2s", "10m"})
+}
+
+func TestInvalidSSLUseSessionTickets(t *testing.T) {
+	testInvalidValues(t, newTestSSLConfig, "UseSessionTickets", "useSessionTickets", []string{"0", "-1", "foobar"})
+}
+
+func TestValidSSLUseSessionTickets(t *testing.T) {
+	testValidValues(t, newTestSSLConfig, "UseSessionTickets", "useSessionTickets", []string{"true", "false", "TRUE", "FALSE"})
+}
+
+func TestInvalidSSLBufferSize(t *testing.T) {
+	testInvalidValues(t, newTestSSLConfig, "BufferSize", "bufferSize", []string{"0", "-1", "foobar"})
+}
+
+func TestValidSSLBufferSize(t *testing.T) {
+	testValidValues(t, newTestSSLConfig, "BufferSize", "bufferSize", []string{"1", "2", "20", "1k", "2k", "10m", "10M"})
+}
+
+func TestInvalidHSTSEnabled(t *testing.T) {
+	testInvalidValues(t, newTestHSTSConfig, "Enabled", "enabled", []string{"0", "-1", "foobar"})
+}
+
+func TestValidHSTSEnabled(t *testing.T) {
+	testValidValues(t, newTestHSTSConfig, "Enabled", "enabled", []string{"true", "false", "TRUE", "FALSE"})
+}
+
+func TestInvalidHSTSMaxAge(t *testing.T) {
+	testInvalidValues(t, newTestHSTSConfig, "MaxAge", "maxAge", []string{"0", "-1", "foobar"})
+}
+
+func TestValidHSTSMaxAge(t *testing.T) {
+	testValidValues(t, newTestHSTSConfig, "MaxAge", "maxAge", []string{"1", "2", "15552000"})
+}
+
+func TestInvalidHSTSIncludeSubDomains(t *testing.T) {
+	testInvalidValues(t, newTestHSTSConfig, "IncludeSubDomains", "includeSubDomains", []string{"0", "-1", "foobar"})
+}
+
+func TestValidHSTSIncludeSubDomains(t *testing.T) {
+	testValidValues(t, newTestHSTSConfig, "IncludeSubDomains", "includeSubDomains", []string{"true", "false", "TRUE", "FALSE"})
+}
+
+func TestInvalidHSTSPreload(t *testing.T) {
+	testInvalidValues(t, newTestHSTSConfig, "Preload", "preload", []string{"0", "-1", "foobar"})
+}
+
+func TestValidHSTSPreload(t *testing.T) {
+	testValidValues(t, newTestHSTSConfig, "Preload", "preload", []string{"true", "false", "TRUE", "FALSE"})
+}
+
+func testInvalidValues(t *testing.T, builder func() interface{}, fieldName string, key string, badValues []string) {
+	badMap := make(map[string]string, 1)
+	for _, badValue := range badValues {
+		badMap[key] = badValue
+		model := builder()
+		err := testModeler.MapToModel(badMap, model)
+		checkError(t, badValue, err)
+	}
+}
+
+func testValidValues(t *testing.T, builder func() interface{}, fieldName string, key string, goodValues []string) {
+	goodMap := make(map[string]string, 1)
+	for _, goodValue := range goodValues {
+		goodMap[key] = goodValue
+		model := builder()
+		err := testModeler.MapToModel(goodMap, model)
+		if err != nil {
+			t.Errorf("Using value \"%s\", received an unexpected error: %s", goodValue, err)
+			t.FailNow()
+		}
+	}
+}
+
+func newTestRouterConfig() interface{} {
+	return newRouterConfig()
+}
+
+func newTestGzipConfig() interface{} {
+	return newGzipConfig()
+}
+
+func newTestAppConfig() interface{} {
+	return newAppConfig(newRouterConfig())
+}
+
+func newTestBuilderConfig() interface{} {
+	return newBuilderConfig()
+}
+
+func newTestSSLConfig() interface{} {
+	return newSSLConfig()
+}
+
+func newTestHSTSConfig() interface{} {
+	return newHSTSConfig()
+}
+
+func checkError(t *testing.T, value string, err error) {
+	want := "modeler.ModelValidationError"
+	if err == nil {
+		t.Errorf("Using value \"%s\", expected a %s, but did not receive any error", value, want)
+		t.FailNow()
+	}
+	if got := reflect.TypeOf(err).String(); want != got {
+		t.Errorf("Using value \"%s\", expected a %s, but got a %s", value, want, got)
+	}
+}

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -30,7 +30,7 @@ http {
 
 	# The timeout value must be greater than the front facing load balancers timeout value.
 	# Default is the deis recommended timeout value for ELB - 1200 seconds + 100s extra.
-	keepalive_timeout {{ $routerConfig.DefaultTimeout }}s;
+	keepalive_timeout {{ $routerConfig.DefaultTimeout }};
 
 	types_hash_max_size 2048;
 	server_names_hash_max_size {{ $routerConfig.ServerNameHashMaxSize }};
@@ -45,7 +45,7 @@ http {
 	gzip_proxied {{ $gzipConfig.Proxied }};
 	gzip_vary {{ $gzipConfig.Vary }};{{ end }}
 
-	client_max_body_size {{ $routerConfig.BodySize }}m;
+	client_max_body_size {{ $routerConfig.BodySize }};
 
 	{{ if $routerConfig.UseProxyProtocol }}set_real_ip_from {{ $routerConfig.ProxyRealIPCIDR }};
 	real_ip_header proxy_protocol;
@@ -128,8 +128,8 @@ http {
 		ssl_certificate_key /opt/nginx/ssl/{{ $domain }}.key;
 		{{ if ne $sslConfig.SessionCache "" }}ssl_session_cache {{ $sslConfig.SessionCache }};
 		ssl_session_timeout {{ $sslConfig.SessionTimeout }};{{ end }}
-		ssl_session_tickets {{ $sslConfig.SessionTickets }};
-		ssl_buffer_size {{ $sslConfig.BufferSize }}k;
+		ssl_session_tickets {{ if $sslConfig.UseSessionTickets }}on{{ else }}off{{ end }};
+		ssl_buffer_size {{ $sslConfig.BufferSize }};
 		{{ if ne $sslConfig.DHParam "" }}ssl_dhparam /opt/nginx/ssl/dhparam.pem;{{ end }}
 		{{ end }}
 
@@ -142,9 +142,9 @@ http {
 			proxy_set_header Host $host;
 			proxy_set_header X-Forwarded-For {{ if $routerConfig.UseProxyProtocol }}$proxy_protocol_addr{{ else }}$proxy_add_x_forwarded_for{{ end }};
 			proxy_redirect off;
-			proxy_connect_timeout {{ $appConfig.ConnectTimeout }}s;
-			proxy_send_timeout {{ $appConfig.TCPTimeout }}s;
-			proxy_read_timeout {{ $appConfig.TCPTimeout }}s;
+			proxy_connect_timeout {{ $appConfig.ConnectTimeout }};
+			proxy_send_timeout {{ $appConfig.TCPTimeout }};
+			proxy_read_timeout {{ $appConfig.TCPTimeout }};
 			proxy_http_version 1.1;
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection $connection_upgrade;
@@ -165,8 +165,8 @@ http {
 {{ if $routerConfig.BuilderConfig }}{{ $builderConfig := $routerConfig.BuilderConfig }}stream {
 	server {
 		listen 2222;
-		proxy_connect_timeout {{ $builderConfig.ConnectTimeout }}s;
-		proxy_timeout {{ $builderConfig.TCPTimeout }}s;
+		proxy_connect_timeout {{ $builderConfig.ConnectTimeout }};
+		proxy_timeout {{ $builderConfig.TCPTimeout }};
 		proxy_pass {{$builderConfig.ServiceIP}}:2222;
 	}
 }{{ end }}

--- a/utils/modeler/errors.go
+++ b/utils/modeler/errors.go
@@ -59,3 +59,23 @@ func newNonStructPointerModelError(tipe reflect.Type) NonStructPointerModelError
 func (e NonStructPointerModelError) Error() string {
 	return fmt.Sprintf("Cannot populate non-struct-pointer type %s from the map.", e.tipe)
 }
+
+// ModelValidationError represents an error resulting from a field having a value that doesn't
+// satisfy a prescribed constraint.
+type ModelValidationError struct {
+	field      string
+	constraint string
+	value      string
+}
+
+func newModelValidationError(field string, constraint string, value string) ModelValidationError {
+	return ModelValidationError{
+		field:      field,
+		constraint: constraint,
+		value:      value,
+	}
+}
+
+func (e ModelValidationError) Error() string {
+	return fmt.Sprintf("Field \"%s\" value \"%s\" does not satisfy constraint /%s/", e.field, e.value, e.constraint)
+}

--- a/utils/modeler/modeler.go
+++ b/utils/modeler/modeler.go
@@ -2,7 +2,9 @@ package modeler
 
 import (
 	"fmt"
+	"log"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -10,14 +12,21 @@ import (
 // Modeler is a utility for populating an arbitrary model's fields with values from a
 // map[string]string.
 type Modeler struct {
-	prefix string
-	tag    string
+	prefix                string
+	fieldTag              string
+	constraintTag         string
+	warnOnValidationError bool
 }
 
 // NewModeler returns a pointer to a new Modeler, confgiured with the provided map key prefix and
 // struct tag key.
-func NewModeler(prefix string, tag string) *Modeler {
-	return &Modeler{prefix: prefix, tag: tag}
+func NewModeler(prefix string, fieldTag string, constraintTag string, warnOnValidationError bool) *Modeler {
+	return &Modeler{
+		prefix:                prefix,
+		fieldTag:              fieldTag,
+		constraintTag:         constraintTag,
+		warnOnValidationError: warnOnValidationError,
+	}
 }
 
 // MapToModel populates the provided model with values from the provided map.
@@ -49,9 +58,9 @@ func (m *Modeler) mapToModel(data map[string]string, context string, rv reflect.
 	rt := elem.Type()
 	for i := 0; i < rt.NumField(); i++ {
 		rf := rt.Field(i)
-		tagValue := rf.Tag.Get(m.tag)
+		fieldTagValue := rf.Tag.Get(m.fieldTag)
 		// If no tag value is found...
-		if tagValue == "" {
+		if fieldTagValue == "" {
 			// Just move to the next field.
 			continue
 		}
@@ -59,9 +68,9 @@ func (m *Modeler) mapToModel(data map[string]string, context string, rv reflect.
 			// We're nested... use some recursion...
 			var nestedContext string
 			if context == "" {
-				nestedContext = tagValue
+				nestedContext = fieldTagValue
 			} else {
-				nestedContext = fmt.Sprintf("%s.%s", context, tagValue)
+				nestedContext = fmt.Sprintf("%s.%s", context, fieldTagValue)
 			}
 			err := m.mapToModel(data, nestedContext, elem.Field(i))
 			if err != nil {
@@ -71,12 +80,25 @@ func (m *Modeler) mapToModel(data map[string]string, context string, rv reflect.
 			// We're not nested!
 			var key string
 			if context == "" {
-				key = fmt.Sprintf("%s/%s", m.prefix, tagValue)
+				key = fmt.Sprintf("%s/%s", m.prefix, fieldTagValue)
 			} else {
-				key = fmt.Sprintf("%s/%s.%s", m.prefix, context, tagValue)
+				key = fmt.Sprintf("%s/%s.%s", m.prefix, context, fieldTagValue)
 			}
 			stringVal, ok := data[key]
 			if ok {
+				constraintTagValue := rf.Tag.Get(m.constraintTag)
+				if constraintTagValue != "" {
+					constraint := regexp.MustCompile(constraintTagValue)
+					if !constraint.MatchString(stringVal) {
+						err := newModelValidationError(key, constraintTagValue, stringVal)
+						if m.warnOnValidationError {
+							log.Printf("WARNING: %s -- skipping this field and using default value \"%v\".", err, elem.Field(i))
+							continue
+						} else {
+							return err
+						}
+					}
+				}
 				if rf.Type.Kind() == reflect.String {
 					elem.Field(i).Set(reflect.ValueOf(stringVal))
 				} else if rf.Type.Kind() == reflect.Int {

--- a/utils/modeler/modeler.go
+++ b/utils/modeler/modeler.go
@@ -79,10 +79,14 @@ func (m *Modeler) mapToModel(data map[string]string, context string, rv reflect.
 		} else {
 			// We're not nested!
 			var key string
+			prefix := m.prefix
+			if prefix != "" && !strings.HasSuffix(prefix, "/") {
+				prefix = fmt.Sprintf("%s/", prefix)
+			}
 			if context == "" {
-				key = fmt.Sprintf("%s/%s", m.prefix, fieldTagValue)
+				key = fmt.Sprintf("%s%s", prefix, fieldTagValue)
 			} else {
-				key = fmt.Sprintf("%s/%s.%s", m.prefix, context, fieldTagValue)
+				key = fmt.Sprintf("%s%s.%s", prefix, context, fieldTagValue)
 			}
 			stringVal, ok := data[key]
 			if ok {

--- a/utils/modeler/modeler_test.go
+++ b/utils/modeler/modeler_test.go
@@ -9,17 +9,19 @@ import (
 )
 
 const (
-	prefix string = "sample"
-	tag    string = "sample"
+	prefix        string = "sample"
+	fieldTag      string = "sample"
+	constraintTag string = "constraint"
 )
 
 var (
-	sampleData = make(map[string]string, 0)
-	m          = NewModeler(prefix, tag)
+	sampleData        = make(map[string]string, 0)
+	invalidSampleData = make(map[string]string, 0)
+	m                 = NewModeler(prefix, fieldTag, constraintTag, false)
 )
 
 type SampleModel struct {
-	SampleString      string          `sample:"a_string"`
+	SampleString      string          `sample:"a_string" constraint:"^foobar$"`
 	SampleInt         int             `sample:"an_int"`
 	SampleBool        bool            `sample:"a_bool"`
 	SampleStringSlice []string        `sample:"a_string_slice"`
@@ -78,6 +80,12 @@ func TestNonPointerSubModel(t *testing.T) {
 	sampleModel := newBadSampleModel()
 	err := m.MapToModel(sampleData, sampleModel)
 	checkError(t, "modeler.NonPointerModelError", err)
+}
+
+func TestValidationError(t *testing.T) {
+	sampleModel := newSampleModel()
+	err := m.MapToModel(invalidSampleData, sampleModel)
+	checkError(t, "modeler.ModelValidationError", err)
 }
 
 func TestMapping(t *testing.T) {
@@ -141,6 +149,7 @@ func checkStringSliceField(t *testing.T, want string, got []string) {
 
 func TestMain(m *testing.M) {
 	initializeSampleData()
+	initializeInvalidSampleData()
 	os.Exit(m.Run())
 }
 
@@ -156,4 +165,8 @@ func initializeSampleData() {
 	sampleData[prefix+"/a_submodel.an_int"] = "5"
 	sampleData[prefix+"/a_submodel.a_bool"] = "true"
 	sampleData[prefix+"/a_submodel.a_string_slice"] = "foo,bar,baz"
+}
+
+func initializeInvalidSampleData() {
+	invalidSampleData[prefix+"/a_string"] = "invalid value"
 }


### PR DESCRIPTION
Fixes #96

This PR attempts to validate configuration values sourced from k8s annotations _before_ they make their way into dynamically generated Nginx configuration.

Before this PR, bad configuration values may have led to unfriendly error messages like this:

```
2016/02/02 23:59:20 [emerg] 14#0: "worker_processes" directive invalid value in /opt/nginx/conf/nginx.conf:4
nginx: [emerg] "worker_processes" directive invalid value in /opt/nginx/conf/nginx.conf:4
```

At minimum, the above requires anyone troubleshooting to `kubectl exec` to a router pod to inspect the resulting invalid Nginx configuration.  At worst, they may need to look at router code to get a better handle on what went wrong.

After this PR, however, declarative constraints (simple regular expressions) are used by the map -> model utility to recognize bad configuration up front.  This allows the router to pinpoint which k8s annotation is the source of the problem.  It also allows Nginx to continue functioning using default configuration in place of the bad value.

For example:

```
2016/02/02 23:51:39 WARNING: Field "router.deis.io/workerProcesses" value "otto" does not satisfy constraint /^(auto|[1-9]\d*)$/ -- skipping this field and using default value "auto".
```