### PR TITLE
feat(router): Enable vts module

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ _Note that Kubernetes annotation maps are all of Go type `map[string]string`.  A
 |-----------|------------|---------------|-------------|
 | deis-router | router.deis.io/workerProcesses | `"auto"` (number of CPU cores) | Number of worker processes to start. |
 | deis-router | router.deis.io/workerConnections| `"768"` | Maximum number of simultaneous connections that can be opened by a worker process. |
+| deis-router | router.deis.io/trafficStatusZoneSize | `"1m"` | Size of a shared memory zone for storing stats collected by the Nginx [VTS module](https://github.com/vozlt/nginx-module-vts#vhost_traffic_status_zone) expressed in bytes (no suffix), kilobytes (suffixes `k` and `K`), or megabytes (suffixes `m` and `M`). |
 | deis-router | router.deis.io/defaultTimeout | `"1300s"` | Default timeout value expressed in units `ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `y`.  Should be longer than the front-facing load balancer's idle timeout. |
 | deis-router | router.deis.io/serverNameHashMaxSize | `"512"` | nginx `server_names_hash_max_size` setting expressed in bytes (no suffix), kilobytes (suffixes `k` and `K`), or megabytes (suffixes `m` and `M`). |
 | deis-router | router.deis.io/serverNameHashBucketSize | `"64"` | nginx `server_names_hash_bucket_size` setting expressed in bytes (no suffix), kilobytes (suffixes `k` and `K`), or megabytes (suffixes `m` and `M`). |

--- a/model/model.go
+++ b/model/model.go
@@ -28,6 +28,7 @@ var (
 type RouterConfig struct {
 	WorkerProcesses          string      `key:"workerProcesses" constraint:"^(auto|[1-9]\\d*)$"`
 	MaxWorkerConnections     string      `key:"maxWorkerConnections" constraint:"^[1-9]\\d*$"`
+	TrafficStatusZoneSize    string      `key:"trafficStatusZoneSize" constraint:"^[1-9]\\d*[kKmM]?$"`
 	DefaultTimeout           string      `key:"defaultTimeout" constraint:"^[1-9]\\d*(ms|[smhdwMy])?$"`
 	ServerNameHashMaxSize    string      `key:"serverNameHashMaxSize" constraint:"^[1-9]\\d*[kKmM]?$"`
 	ServerNameHashBucketSize string      `key:"serverNameHashBucketSize" constraint:"^[1-9]\\d*[kKmM]?$"`
@@ -48,6 +49,7 @@ func newRouterConfig() *RouterConfig {
 	return &RouterConfig{
 		WorkerProcesses:          "auto",
 		MaxWorkerConnections:     "768",
+		TrafficStatusZoneSize:    "1m",
 		DefaultTimeout:           "1300s",
 		ServerNameHashMaxSize:    "512",
 		ServerNameHashBucketSize: "64",

--- a/model/model_validation_test.go
+++ b/model/model_validation_test.go
@@ -31,6 +31,14 @@ func TestValidMaxWorkerConnections(t *testing.T) {
 	testValidValues(t, newTestRouterConfig, "MaxWorkerConnections", "maxWorkerConnections", []string{"1", "2", "10"})
 }
 
+func TestInvalidTrafficStatusZoneSize(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "TrafficStatusZoneSize", "trafficStatusZoneSize", []string{"0", "-1", "foobar"})
+}
+
+func TestValidTrafficStatusZoneSize(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "TrafficStatusZoneSize", "trafficStatusZoneSize", []string{"1", "2", "20", "1k", "2k", "10m", "10M"})
+}
+
 func TestInvalidDefaultTimeout(t *testing.T) {
 	testInvalidValues(t, newTestRouterConfig, "DefaultTimeout", "defaultTimeout", []string{"0", "-1", "foobar"})
 }

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -28,6 +28,8 @@ http {
 	tcp_nopush on;
 	tcp_nodelay on;
 
+	vhost_traffic_status_zone shared:vhost_traffic_status:{{ $routerConfig.TrafficStatusZoneSize }};
+
 	# The timeout value must be greater than the front facing load balancers timeout value.
 	# Default is the deis recommended timeout value for ELB - 1200 seconds + 100s extra.
 	keepalive_timeout {{ $routerConfig.DefaultTimeout }};
@@ -109,6 +111,12 @@ http {
 			access_log off;
 			default_type 'text/plain';
 			return 200;
+		}
+		location ~ ^/stats/?$ {
+			vhost_traffic_status_display;
+			vhost_traffic_status_display_format json;
+			allow 127.0.0.1;
+			deny all;
 		}
 		location / {
 			return 404;

--- a/rootfs/bin/build
+++ b/rootfs/bin/build
@@ -3,6 +3,7 @@
 set -eof pipefail
 
 export NGINX_VERSION=1.9.6
+export VTS_VERSION=0.1.8
 
 export BUILD_PATH=/tmp/build
 
@@ -32,6 +33,9 @@ apk add --update-cache \
 get_src ed501fc6d0eff9d3bc1049cc1ba3a3ac8c602de046acb2a4c108392bbfa865ea \
         "http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
 
+get_src 6bb9a36d8d70302d691c49557313fb7262cafd942a961d11a2730d9a5d9f70e0 \
+        "https://github.com/vozlt/nginx-module-vts/archive/v$VTS_VERSION.tar.gz"
+
 # build nginx
 cd "$BUILD_PATH/nginx-$NGINX_VERSION"
 
@@ -54,6 +58,7 @@ cd "$BUILD_PATH/nginx-$NGINX_VERSION"
   --with-mail \
   --with-mail_ssl_module \
   --with-stream \
+  --add-module="$BUILD_PATH/nginx-module-vts-$VTS_VERSION" \
   && make && make install
 
 rm -rf "$BUILD_PATH"


### PR DESCRIPTION
Fixes #98 

Relates to #90 

This enables the Nginx VTS module to gather stats and expose them as JSON, but _only_ allows access to those stats from within the pod (I feel pretty strongly that these should not be exposed to the outside world).

cc @jchauncey: Take a look and let me know if this meets your needs.