### PR TITLE
ref(router): Refactor cert management

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ _Note that Kubernetes annotation maps are all of Go type `map[string]string`.  A
 | deis-builder | router.deis.io/connectTimeout | `"10s"` | nginx `proxy_connect_timeout` setting expressed in units `ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `y`. |
 | deis-builder | router.deis.io/tcpTimeout | `"1200s"` | nginx `proxy_timeout` setting expressed in units `ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `y`. |
 | routable application | router.deis.io/domains | N/A | Comma-delimited list of domains for which traffic should be routed to the application.  These may be fully qualified (e.g. `foo.example.com`) or, if not containing any `.` character, will be considered subdomains of the router's domain, if that is defined. |
+| <a name="certificates-annotation"></a>routable application | router.deis.io/certificates | N/A | Comma delimited list of mappings between domain names (see `router.deis.io/domains`) and the certificate to be used for each.  The domain name and certificate name must be separated by a colon.  See the [SSL section](#ssl) below for further details. |
 | routable application | router.deis.io/whitelist | N/A | Comma-delimited list of addresses permitted to access the application (using IP or CIDR notation).  These may either extend or override the router-wide default whitelist (if defined).  Requests from all other addresses are denied. |
 | routable application | router.deis.io/connectTimeout | `"30s"` | nginx `proxy_connect_timeout` setting expressed in units `ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `y`. |
 | routable application | router.deis.io/tcpTimeout | router's `defaultTimeout` | nginx `proxy_send_timeout` and `proxy_read_timeout` settings expressed in units `ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `y`. |
@@ -299,7 +300,7 @@ metadata:
 # ...
 ```
 
-### SSL
+### <a name="ssl"></a>SSL
 
 Router has support for HTTPS with the ability to perform SSL termination using certificates supplied via Kubernetes secrets.  Just as router utilizes the Kubernetes API to discover routable services, router also uses the API to discover cert-bearing secrets.  This allows the router to dynamically refresh and reload configuration whenever such a certificate is added, updated, or removed.  There is never a need to explicitly restart the router.
 
@@ -309,13 +310,27 @@ A certificate may be supplied in the manner described above and can be used to p
 
 Here is an example of a Kubernetes secret bearing a certificate for use with a specific fully-qualified domain name.  The following criteria must be met:
 
-* Must be named `<domain>-cert`
+* Secret name must be for the form `<arbitrary name>-cert`
+  * This must be associated to the domain using the [router.deis.io/certificates](#certificates-annotation) annotation.
 * Must be in the same namespace as the routable service
 * Certificate must be supplied as the value of the key `cert`
 * Certificate private key must be supplied as the value of the key `key`
 * Both the certificate and private key must be base64 encoded
 
-For example, assuming a routable service exists in the namespace `cheery-yardbird` and lists `www.example.com` among its associated domains, the `www.example.com` certificate (or a wildcard `*.example.com` certificate) could be supplied as follows:
+For example, assuming a routable service exists in the namespace `cheery-yardbird` and is configured with `www.example.com` among its domains, like so:
+
+```
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: cheery-yardbird
+  annotations:
+    router.deis.io/domains: cheery-yardbird,www.example.com
+    router.deis.io/certificates: www.example.com:www-example-com"
+# ...
+```
+
+The corresponding cert-bearing secret would appear as follows:
 
 ```
 apiVersion: v1
@@ -331,7 +346,7 @@ data:
 
 #### Default certificate
 
-A wildcard certificate may be supplied in the manner described above and can be used as a default certificate to provide a secure virtual host (in addition to the insecure virtual host) for _every_ "domain" of a routable service that is not a fully-qualified domain name.
+A wildcard certificate may be supplied in a manner similar to that described above and can be used as a default certificate to provide a secure virtual host (in addition to the insecure virtual host) for _every_ "domain" of a routable service that is not a fully-qualified domain name.
 
 For instance, if a routable service exists having a "domain" `frozen-wookie` and the router's default domain is `example.com`, a supplied wildcard certificate for `*.example.com` will be used to secure a `frozen-wookie.example.com` virtual host.  Similarly, if no default domain is defined, the supplied wildcard certificate will be used to secure a virtual host matching the expression `~^frozen-wookie\.(?<domain>.+)$`.  (The latter is almost certainly guaranteed to result in certificate warnings in an end user's browser, so it is advisable to always define the router's default domain.)
 
@@ -342,7 +357,7 @@ If the same routable service also had a domain `www.frozen-wookie.com`, the `*.e
 Here is an example of a Kubernetes secret bearing a wildcard certificate for use by the router.  The following criteria must be met:
 
 * Namespace must be the same namespace as the router
-* Name must be `deis-router-default-cert`
+* Name _must_ be `deis-router-default-cert`
 * Certificate must be supplied as the value of the key `cert`
 * Certificate private key must be supplied as the value of the key `key`
 * Both the certificate and private key must be base64 encoded

--- a/model/model.go
+++ b/model/model.go
@@ -105,6 +105,7 @@ type AppConfig struct {
 	ConnectTimeout string   `key:"connectTimeout" constraint:"^[1-9]\\d*(ms|[smhdwMy])?$"`
 	TCPTimeout     string   `key:"tcpTimeout" constraint:"^[1-9]\\d*(ms|[smhdwMy])?$"`
 	ServiceIP      string
+	CertMappings   map[string]string `key:"certificates" constraint:"(?i)^((([a-z0-9]+(-[a-z0-9]+)*)|((\\*\\.)?[a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,}):([a-z0-9]+(-[a-z0-9]+)*)(\\s*,\\s*)?)+$"`
 	Certificates   map[string]*Certificate
 }
 
@@ -338,12 +339,7 @@ func buildAppConfig(kubeClient *client.Client, service api.Service, routerConfig
 	for _, domain := range appConfig.Domains {
 		if strings.Contains(domain, ".") {
 			// Look for a cert-bearing secret for this domain.
-			var secretName string
-			if strings.HasPrefix(domain, "*.") {
-				secretName = fmt.Sprintf("%s-wildcard-cert", strings.TrimPrefix(domain, "*."))
-			} else {
-				secretName = fmt.Sprintf("%s-cert", domain)
-			}
+			secretName := fmt.Sprintf("%s-cert", appConfig.CertMappings[domain])
 			certSecret, err := getSecret(kubeClient, secretName, service.Namespace)
 			if err != nil {
 				return nil, err

--- a/model/model.go
+++ b/model/model.go
@@ -100,7 +100,7 @@ func newGzipConfig() *GzipConfig {
 
 // AppConfig encapsulates the configuration for all routes to a single back end.
 type AppConfig struct {
-	Domains        []string `key:"domains" constraint:"(?i)^((([a-z0-9]+(-[a-z0-9]+)*)|([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,})(\\s*,\\s*)?)+$"`
+	Domains        []string `key:"domains" constraint:"(?i)^((([a-z0-9]+(-[a-z0-9]+)*)|((\\*\\.)?[a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,})(\\s*,\\s*)?)+$"`
 	Whitelist      []string `key:"whitelist" constraint:"^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))?(\\s*,\\s*)?)+$"`
 	ConnectTimeout string   `key:"connectTimeout" constraint:"^[1-9]\\d*(ms|[smhdwMy])?$"`
 	TCPTimeout     string   `key:"tcpTimeout" constraint:"^[1-9]\\d*(ms|[smhdwMy])?$"`

--- a/model/model_validation_test.go
+++ b/model/model_validation_test.go
@@ -180,7 +180,7 @@ func TestInvalidAppDomains(t *testing.T) {
 }
 
 func TestValidAppDomains(t *testing.T) {
-	testValidValues(t, newTestAppConfig, "Domains", "domains", []string{"foobar", "foo-bar", "foobar.com", "foobar,foobar.com", "foobar, foobar.com"})
+	testValidValues(t, newTestAppConfig, "Domains", "domains", []string{"foobar", "foo-bar", "foobar.com", "foobar,foobar.com", "foobar, foobar.com", "*.foobar.com"})
 }
 
 func TestInvalidAppWhitelist(t *testing.T) {

--- a/model/model_validation_test.go
+++ b/model/model_validation_test.go
@@ -207,6 +207,14 @@ func TestValidAppTCPTimeout(t *testing.T) {
 	testValidValues(t, newTestAppConfig, "TCPTimeout", "tcpTimeout", []string{"1", "2", "10", "1ms", "2s", "10m"})
 }
 
+func TestInvalidCertMappings(t *testing.T) {
+	testInvalidValues(t, newTestAppConfig, "CertMappings", "certificates", []string{"0", "-1", "foobar"})
+}
+
+func TestValidCertMappings(t *testing.T) {
+	testValidValues(t, newTestAppConfig, "CertMappings", "certificates", []string{"foobar.com:foobar,*.foobar.deis.ninja:foobar-deis-ninja"})
+}
+
 func TestInvalidBuilderConnectTimeout(t *testing.T) {
 	testInvalidValues(t, newTestBuilderConfig, "ConnectTimeout", "connectTimeout", []string{"0", "-1", "foobar"})
 }

--- a/utils/modeler/modeler.go
+++ b/utils/modeler/modeler.go
@@ -123,6 +123,16 @@ func (m *Modeler) mapToModel(data map[string]string, context string, rv reflect.
 						sliceVal[j] = strings.TrimSpace(token)
 					}
 					elem.Field(i).Set(reflect.ValueOf(sliceVal))
+				} else if rf.Type.Kind() == reflect.Map {
+					sliceVal := strings.Split(stringVal, ",")
+					mapVal := make(map[string]string, len(sliceVal))
+					for _, kvStr := range sliceVal {
+						kvTokens := strings.Split(kvStr, ":")
+						key := strings.TrimSpace(kvTokens[0])
+						value := strings.TrimSpace(kvTokens[1])
+						mapVal[key] = value
+					}
+					elem.Field(i).Set(reflect.ValueOf(mapVal))
 				} else {
 					return fmt.Errorf("Unsupported type %s.", rf.Type.Kind())
 				}

--- a/utils/modeler/modeler_test.go
+++ b/utils/modeler/modeler_test.go
@@ -21,11 +21,12 @@ var (
 )
 
 type SampleModel struct {
-	SampleString      string          `sample:"a_string" constraint:"^foobar$"`
-	SampleInt         int             `sample:"an_int"`
-	SampleBool        bool            `sample:"a_bool"`
-	SampleStringSlice []string        `sample:"a_string_slice"`
-	SampleSubModel    *SampleSubModel `sample:"a_submodel"`
+	SampleString      string            `sample:"a_string" constraint:"^foobar$"`
+	SampleInt         int               `sample:"an_int"`
+	SampleBool        bool              `sample:"a_bool"`
+	SampleStringSlice []string          `sample:"a_string_slice"`
+	SampleStringMap   map[string]string `sample:"a_string_map"`
+	SampleSubModel    *SampleSubModel   `sample:"a_submodel"`
 	UnmappedString    string
 }
 
@@ -34,11 +35,12 @@ func newSampleModel() *SampleModel {
 }
 
 type BadSampleModel struct {
-	SampleString      string         `sample:"a_string"`
-	SampleInt         int            `sample:"an_int"`
-	SampleBool        bool           `sample:"a_bool"`
-	SampleStringSlice []string       `sample:"a_string_slice"`
-	SampleSubModel    SampleSubModel `sample:"a_submodel"`
+	SampleString      string            `sample:"a_string"`
+	SampleInt         int               `sample:"an_int"`
+	SampleBool        bool              `sample:"a_bool"`
+	SampleStringSlice []string          `sample:"a_string_slice"`
+	SampleStringMap   map[string]string `sample:"a_string_map"`
+	SampleSubModel    SampleSubModel    `sample:"a_submodel"`
 	UnmappedString    string
 }
 
@@ -98,6 +100,7 @@ func TestMapping(t *testing.T) {
 	checkIntField(t, sampleData[prefix+"/an_int"], sampleModel.SampleInt)
 	checkBoolField(t, sampleData[prefix+"/a_bool"], sampleModel.SampleBool)
 	checkStringSliceField(t, sampleData[prefix+"/a_string_slice"], sampleModel.SampleStringSlice)
+	checkStringMapField(t, sampleData[prefix+"/a_string_map"], sampleModel.SampleStringMap)
 	checkStringField(t, sampleData[prefix+"/a_submodel.a_string"], sampleModel.SampleSubModel.SampleString)
 	checkIntField(t, sampleData[prefix+"/a_submodel.an_int"], sampleModel.SampleSubModel.SampleInt)
 	checkBoolField(t, sampleData[prefix+"/a_submodel.a_bool"], sampleModel.SampleSubModel.SampleBool)
@@ -147,6 +150,20 @@ func checkStringSliceField(t *testing.T, want string, got []string) {
 	}
 }
 
+func checkStringMapField(t *testing.T, want string, got map[string]string) {
+	wantStringSlice := strings.Split(want, ",")
+	wantStringMap := make(map[string]string, len(wantStringSlice))
+	for _, kvStr := range wantStringSlice {
+		kvTokens := strings.Split(kvStr, ":")
+		key := strings.TrimSpace(kvTokens[0])
+		value := strings.TrimSpace(kvTokens[1])
+		wantStringMap[key] = value
+	}
+	if !reflect.DeepEqual(wantStringMap, got) {
+		t.Errorf("Expected %s, but got %s", wantStringMap, got)
+	}
+}
+
 func TestMain(m *testing.M) {
 	initializeSampleData()
 	initializeInvalidSampleData()
@@ -160,6 +177,7 @@ func initializeSampleData() {
 	sampleData[prefix+"/an_int"] = "5"
 	sampleData[prefix+"/a_bool"] = "true"
 	sampleData[prefix+"/a_string_slice"] = "foo,bar,baz"
+	sampleData[prefix+"/a_string_map"] = "foo:bar,bat:baz"
 	// Key/values for a model within the model...
 	sampleData[prefix+"/a_submodel.a_string"] = "foobar"
 	sampleData[prefix+"/a_submodel.an_int"] = "5"


### PR DESCRIPTION
These changes complement @helgi's PR deis/workflow#338, which essentially changes the contract between workflow and router.

The change implemented here fundamentally boils down to:

__Before:__ The name of the secret bearing the certificate for any given domain was assumed to be `<domain>-cert`.

@helgi has significantly improved certificate management in workflow.

__After:__ The `router.deis.io/certificates` annotation provides a simple dictionary that maps domain names to the names of cert-bearing secrets.