### PR TITLE
feat(router): Group stats by app

### DIFF
--- a/nginx/config.go
+++ b/nginx/config.go
@@ -149,6 +149,8 @@ http {
 		deny all;
 		{{ end }}
 
+		vhost_traffic_status_filter_by_set_key {{ $appConfig.Name }} application::*;
+
 		location / {
 			proxy_buffering off;
 			proxy_set_header Host $host;


### PR DESCRIPTION
Relates to #90

This improves the stats that the router exposes by grouping them by application.  Previously, they were only grouped by vhost (Nginx server block), but now they are grouped _both_ ways.

cc @slack and @jchauncey 

Here's an example of the JSON it produces.  Search for "filterZones" to see the new grouping by application.

```
{"nginxVersion":"1.9.6","loadMsec":1455133392421,"nowMsec":1455133637405,"connections":{"active":3,"reading":0,"writing":1,"waiting":2,"accepted":120,"handled":120,"requests":550},"serverZones":{"_":{"requestCounter":542,"inBytes":168677,"outBytes":415059,"responses":{"1xx":0,"2xx":542,"3xx":0,"4xx":0,"5xx":0,"miss":0,"bypass":0,"expired":0,"stale":0,"updating":0,"revalidated":0,"hit":0,"scarce":0},"overCounts":{"maxIntegerSize":18446744073709551615,"requestCounter":0,"inBytes":0,"outBytes":0,"1xx":0,"2xx":0,"3xx":0,"4xx":0,"5xx":0,"miss":0,"bypass":0,"expired":0,"stale":0,"updating":0,"revalidated":0,"hit":0,"scarce":0}},"~^deis\\.(?<domain>.+)$":{"requestCounter":5,"inBytes":1199,"outBytes":2433,"responses":{"1xx":0,"2xx":4,"3xx":0,"4xx":1,"5xx":0,"miss":0,"bypass":0,"expired":0,"stale":0,"updating":0,"revalidated":0,"hit":0,"scarce":0},"overCounts":{"maxIntegerSize":18446744073709551615,"requestCounter":0,"inBytes":0,"outBytes":0,"1xx":0,"2xx":0,"3xx":0,"4xx":0,"5xx":0,"miss":0,"bypass":0,"expired":0,"stale":0,"updating":0,"revalidated":0,"hit":0,"scarce":0}},"~^gentle-question\\.(?<domain>.+)$":{"requestCounter":2,"inBytes":756,"outBytes":442,"responses":{"1xx":0,"2xx":2,"3xx":0,"4xx":0,"5xx":0,"miss":0,"bypass":0,"expired":0,"stale":0,"updating":0,"revalidated":0,"hit":0,"scarce":0},"overCounts":{"maxIntegerSize":18446744073709551615,"requestCounter":0,"inBytes":0,"outBytes":0,"1xx":0,"2xx":0,"3xx":0,"4xx":0,"5xx":0,"miss":0,"bypass":0,"expired":0,"stale":0,"updating":0,"revalidated":0,"hit":0,"scarce":0}},"*":{"requestCounter":549,"inBytes":170632,"outBytes":417934,"responses":{"1xx":0,"2xx":548,"3xx":0,"4xx":1,"5xx":0,"miss":0,"bypass":0,"expired":0,"stale":0,"updating":0,"revalidated":0,"hit":0,"scarce":0},"overCounts":{"maxIntegerSize":18446744073709551615,"requestCounter":0,"inBytes":0,"outBytes":0,"1xx":0,"2xx":0,"3xx":0,"4xx":0,"5xx":0,"miss":0,"bypass":0,"expired":0,"stale":0,"updating":0,"revalidated":0,"hit":0,"scarce":0}}},"filterZones":{"application::*":{"deis-workflow":{"requestCounter":5,"inBytes":1199,"outBytes":2433,"responses":{"1xx":0,"2xx":4,"3xx":0,"4xx":1,"5xx":0,"miss":0,"bypass":0,"expired":0,"stale":0,"updating":0,"revalidated":0,"hit":0,"scarce":0},"overCounts":{"maxIntegerSize":18446744073709551615,"requestCounter":0,"inBytes":0,"outBytes":0,"1xx":0,"2xx":0,"3xx":0,"4xx":0,"5xx":0,"miss":0,"bypass":0,"expired":0,"stale":0,"updating":0,"revalidated":0,"hit":0,"scarce":0}},"gentle-question":{"requestCounter":2,"inBytes":756,"outBytes":442,"responses":{"1xx":0,"2xx":2,"3xx":0,"4xx":0,"5xx":0,"miss":0,"bypass":0,"expired":0,"stale":0,"updating":0,"revalidated":0,"hit":0,"scarce":0},"overCounts":{"maxIntegerSize":18446744073709551615,"requestCounter":0,"inBytes":0,"outBytes":0,"1xx":0,"2xx":0,"3xx":0,"4xx":0,"5xx":0,"miss":0,"bypass":0,"expired":0,"stale":0,"updating":0,"revalidated":0,"hit":0,"scarce":0}}}},"upstreamZones":{"::nogroups":[{"server":"10.3.0.17:80","requestCounter":5,"inBytes":1199,"outBytes":2433,"responses":{"1xx":0,"2xx":4,"3xx":0,"4xx":1,"5xx":0},"responseMsec":35,"weight":0,"maxFails":0,"failTimeout":0,"backup":false,"down":false,"overCounts":{"maxIntegerSize":18446744073709551615,"requestCounter":0,"inBytes":0,"outBytes":0,"1xx":0,"2xx":0,"3xx":0,"4xx":0,"5xx":0}},{"server":"10.3.0.63:80","requestCounter":2,"inBytes":756,"outBytes":442,"responses":{"1xx":0,"2xx":2,"3xx":0,"4xx":0,"5xx":0},"responseMsec":6,"weight":0,"maxFails":0,"failTimeout":0,"backup":false,"down":false,"overCounts":{"maxIntegerSize":18446744073709551615,"requestCounter":0,"inBytes":0,"outBytes":0,"1xx":0,"2xx":0,"3xx":0,"4xx":0,"5xx":0}}]}}
```