### PR TITLE
doc(router): Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ $ helm repo add deis https://github.com/deis/charts
 To install the router:
 
 ```
-$ helm install deis/<chart>
+$ helm fetch deis/<chart>
+$ helm generate <chart>
+$ helm install <chart>
 ```
 Where `<chart>` is selected from the options below:
 


### PR DESCRIPTION
Install instructions were not updated after the need for running `helm generate <chart>` was introduced for some charts that contain templates (i.e. `deis-dev`).

This fixes that.