### PR TITLE
ref(router): Run as a non-root user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 manifests/deis-router-rc.tmp.yaml
-rootfs/bin/router
+rootfs/opt/router/sbin/router
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_CMD := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
 DEV_ENV_CMD_INT := docker run -it --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
 LDFLAGS := "-s -X main.version=${VERSION}"
-BINDIR := ./rootfs/bin
+BINDIR := ./rootfs/opt/router/sbin
 
 # The following variables describe the source we build from
 GO_FILES := $(wildcard *.go)

--- a/nginx/commands.go
+++ b/nginx/commands.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	nginxBinary = "/opt/nginx/sbin/nginx"
+	nginxBinary = "/opt/router/sbin/nginx"
 )
 
 // Start nginx.

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -12,9 +12,8 @@ import (
 )
 
 const (
-	confTemplate = `{{ $routerConfig := . }}user nginx;
-daemon off;
-pid /run/nginx.pid;
+	confTemplate = `{{ $routerConfig := . }}daemon off;
+pid /tmp/nginx.pid;
 worker_processes {{ $routerConfig.WorkerProcesses }};
 
 events {
@@ -56,8 +55,8 @@ http {
 
 	log_format upstreaminfo '[$time_local] - $remote_addr - $remote_user - $status - "$request" - $bytes_sent - "$http_referer" - "$http_user_agent" - "$server_name" - $upstream_addr - $http_host - $upstream_response_time - $request_time';
 
-	access_log /opt/nginx/logs/access.log upstreaminfo;
-	error_log  /opt/nginx/logs/error.log {{ $routerConfig.ErrorLogLevel }};
+	access_log /opt/router/logs/access.log upstreaminfo;
+	error_log  /opt/router/logs/error.log {{ $routerConfig.ErrorLogLevel }};
 
 	map $http_upgrade $connection_upgrade {
 		default upgrade;
@@ -89,8 +88,8 @@ http {
 		{{ if $routerConfig.DefaultCertificate }}
 		listen 443 default_server ssl{{ if $routerConfig.UseProxyProtocol }} proxy_protocol{{ end }};
 		ssl_protocols {{ $sslConfig.Protocols }};
-		ssl_certificate /opt/nginx/ssl/default.crt;
-		ssl_certificate_key /opt/nginx/ssl/default.key;
+		ssl_certificate /opt/router/ssl/default.crt;
+		ssl_certificate_key /opt/router/ssl/default.key;
 		{{ end }}
 		server_name _;
 		location ~ ^/healthz/?$ {
@@ -134,13 +133,13 @@ http {
 		ssl_protocols {{ $sslConfig.Protocols }};
 		{{ if ne $sslConfig.Ciphers "" }}ssl_ciphers {{ $sslConfig.Ciphers }};{{ end }}
 		ssl_prefer_server_ciphers on;
-		ssl_certificate /opt/nginx/ssl/{{ $domain }}.crt;
-		ssl_certificate_key /opt/nginx/ssl/{{ $domain }}.key;
+		ssl_certificate /opt/router/ssl/{{ $domain }}.crt;
+		ssl_certificate_key /opt/router/ssl/{{ $domain }}.key;
 		{{ if ne $sslConfig.SessionCache "" }}ssl_session_cache {{ $sslConfig.SessionCache }};
 		ssl_session_timeout {{ $sslConfig.SessionTimeout }};{{ end }}
 		ssl_session_tickets {{ if $sslConfig.UseSessionTickets }}on{{ else }}off{{ end }};
 		ssl_buffer_size {{ $sslConfig.BufferSize }};
-		{{ if ne $sslConfig.DHParam "" }}ssl_dhparam /opt/nginx/ssl/dhparam.pem;{{ end }}
+		{{ if ne $sslConfig.DHParam "" }}ssl_dhparam /opt/router/ssl/dhparam.pem;{{ end }}
 		{{ end }}
 
 		{{ if or $routerConfig.EnforceWhitelists (or (ne (len $routerConfig.DefaultWhitelist) 0) (ne (len $appConfig.Whitelist) 0)) }}

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -9,26 +9,34 @@ RUN apk add --update-cache \
 	openssl \
 	pcre \
 	sudo \
+	libcap \
 	&& rm -rf /var/cache/apk/*
 
-# add nginx user
-RUN addgroup -S nginx && \
-  adduser -S -G nginx -H -h /opt/nginx -s /sbin/nologin -D nginx
+# add router user
+RUN addgroup -S router && \
+	adduser -S -G router -H -h /opt/router -D router
 
 COPY . /
 
 # compile nginx from source
 RUN build
 
-# Re-copy this file because the previous step will have overwritten it
-COPY opt/nginx/conf/nginx.conf /opt/nginx/conf/nginx.conf
+# Re-copy these files because the previous step will have overwritten them
+COPY opt/router /opt/router
 
-RUN mkdir /opt/nginx/ssl
+RUN mkdir /opt/router/ssl
 
-RUN ln -sf /dev/stdout /opt/nginx/logs/access.log
-RUN ln -sf /dev/stderr /opt/nginx/logs/error.log
+RUN ln -sf /dev/stdout /opt/router/logs/access.log && \
+	ln -sf /dev/stderr /opt/router/logs/error.log
 
-CMD ["/bin/router"]
+# Fix some permission since we'll be running as a non-root user.  This includes enabling
+# Nginx to always bind to low/privileged ports, even when running as a non-root user.
+RUN chown -R router:router /opt/router && \
+	setcap 'cap_net_bind_service=+ep' /opt/router/sbin/nginx
+
+USER router
+
+CMD ["/opt/router/sbin/router"]
 EXPOSE 80 2222 9090
 
 ENV DEIS_RELEASE 2.0.0

--- a/rootfs/bin/build
+++ b/rootfs/bin/build
@@ -8,7 +8,7 @@ export VTS_VERSION=0.1.8
 export BUILD_PATH=/tmp/build
 
 # nginx installation directory
-export PREFIX=/opt/nginx
+export PREFIX=/opt/router
 
 rm -rf "$PREFIX"
 mkdir "$PREFIX"
@@ -41,7 +41,7 @@ cd "$BUILD_PATH/nginx-$NGINX_VERSION"
 
 ./configure \
   --prefix="$PREFIX" \
-  --pid-path=/run/nginx.pid \
+  --pid-path=/tmp/nginx.pid \
   --with-debug \
   --with-pcre-jit \
   --with-ipv6 \

--- a/rootfs/opt/router/conf/nginx.conf
+++ b/rootfs/opt/router/conf/nginx.conf
@@ -1,4 +1,3 @@
-user nginx;
 daemon off;
 events {}
 http {}

--- a/router.go
+++ b/router.go
@@ -30,17 +30,17 @@ func main() {
 			continue
 		}
 		log.Println("INFO: Router configuration has changed in k8s.")
-		err = nginx.WriteCerts(routerConfig, "/opt/nginx/ssl")
+		err = nginx.WriteCerts(routerConfig, "/opt/router/ssl")
 		if err != nil {
 			log.Printf("Failed to write certs; continuing with existing certs, dhparam, and configuration: %v", err)
 			continue
 		}
-		err = nginx.WriteDHParam(routerConfig, "/opt/nginx/ssl")
+		err = nginx.WriteDHParam(routerConfig, "/opt/router/ssl")
 		if err != nil {
 			log.Printf("Failed to write dhparam; continuing with existing dhparam and configuration: %v", err)
 			continue
 		}
-		err = nginx.WriteConfig(routerConfig, "/opt/nginx/conf/nginx.conf")
+		err = nginx.WriteConfig(routerConfig, "/opt/router/conf/nginx.conf")
 		if err != nil {
 			log.Printf("Failed to write new nginx configuration; continuing with existing configuration: %v", err)
 			continue


### PR DESCRIPTION
Fixes #120 

This wasn't easy.  Running router as a non-privileged user means router can't su to start Nginx as a second unprivileged user `nginx`.  The solution is to move _everything_-- all files and processes under a new `router` user.  This works great except for a limitation that unprivileged users cannot bind to low-numbered/privileged ports like 80 and 443.  That's where `setcap` comes in.