### PR TITLE
fix(router): Fix log permissions for non-root user

### DIFF
--- a/nginx/config.go
+++ b/nginx/config.go
@@ -55,8 +55,8 @@ http {
 
 	log_format upstreaminfo '[$time_local] - $remote_addr - $remote_user - $status - "$request" - $bytes_sent - "$http_referer" - "$http_user_agent" - "$server_name" - $upstream_addr - $http_host - $upstream_response_time - $request_time';
 
-	access_log /opt/router/logs/access.log upstreaminfo;
-	error_log  /opt/router/logs/error.log {{ $routerConfig.ErrorLogLevel }};
+	access_log /tmp/logpipe upstreaminfo;
+	error_log  /tmp/logpipe {{ $routerConfig.ErrorLogLevel }};
 
 	map $http_upgrade $connection_upgrade {
 		default upgrade;

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -26,9 +26,6 @@ COPY opt/router /opt/router
 
 RUN mkdir /opt/router/ssl
 
-RUN ln -sf /dev/stdout /opt/router/logs/access.log && \
-	ln -sf /dev/stderr /opt/router/logs/error.log
-
 # Fix some permission since we'll be running as a non-root user.  This includes enabling
 # Nginx to always bind to low/privileged ports, even when running as a non-root user.
 RUN chown -R router:router /opt/router && \
@@ -36,7 +33,7 @@ RUN chown -R router:router /opt/router && \
 
 USER router
 
-CMD ["/opt/router/sbin/router"]
+CMD ["/opt/router/sbin/boot"]
 EXPOSE 80 2222 9090
 
 ENV DEIS_RELEASE 2.0.0

--- a/rootfs/opt/router/sbin/boot
+++ b/rootfs/opt/router/sbin/boot
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eof pipefail
+
+mkfifo -m 600 /tmp/logpipe
+cat < /tmp/logpipe 1>&2 &
+
+exec /opt/router/sbin/router


### PR DESCRIPTION
#120 turned out to not work nicely with Docker < 1.9.

This PR corrects that.

cc @arschles 