### PR TITLE
feat(certs): Add support for format of ingress TLS cert secrets

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -386,17 +386,23 @@ func buildBuilderConfig(service *api.Service) (*BuilderConfig, error) {
 }
 
 func buildCertificate(certSecret *api.Secret, context string) (*Certificate, error) {
-	cert, ok := certSecret.Data["cert"]
+	cert, ok := certSecret.Data["tls.crt"]
 	// If no cert is found in the secret, warn and return nil
 	if !ok {
-		log.Printf("WARN: The k8s secret intended to convey the %s certificate contained no entry \"cert\".\n", context)
-		return nil, nil
+		cert, ok = certSecret.Data["cert"]
+		if !ok {
+			log.Printf("WARN: The k8s secret intended to convey the %s certificate contained no entry \"tls.crt\" or \"cert\".\n", context)
+			return nil, nil
+		}
 	}
-	key, ok := certSecret.Data["key"]
+	key, ok := certSecret.Data["tls.key"]
 	// If no key is found in the secret, warn and return nil
 	if !ok {
-		log.Printf("WARN: The k8s secret intended to convey the %s certificate key contained no entry \"key\".\n", context)
-		return nil, nil
+		key, ok = certSecret.Data["key"]
+		if !ok {
+			log.Printf("WARN: The k8s secret intended to convey the %s certificate key contained no entry \"tls.key\" or \"key\".\n", context)
+			return nil, nil
+		}
 	}
 	certStr := string(cert[:])
 	keyStr := string(key[:])


### PR DESCRIPTION
Fixes #154 

Complements https://github.com/deis/controller/pull/577

This should be merged _before_ https://github.com/deis/controller/pull/577, since this will allow both the old format and the new to work simultaneously.  After https://github.com/deis/controller/pull/577 is merged, a follow-up PR can remove the support for the old format from the router...

So yes... this change is partly temporary.

cc @helgi