### PR TITLE
feat(config): add application name as part of the log information

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -333,6 +333,11 @@ func buildAppConfig(kubeClient *client.Client, service api.Service, routerConfig
 	if appConfig.Name == "" {
 		appConfig.Name = service.Name
 	}
+	// if app name and Namespace are not same then combine the two as it
+	// makes deis services (as an example) clearer, such as deis/controller
+	if appConfig.Name != service.Namespace {
+		appConfig.Name = service.Namespace + "/" + appConfig.Name
+	}
 	err := modeler.MapToModel(service.Annotations, "", appConfig)
 	if err != nil {
 		return nil, err

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -58,7 +58,7 @@ http {
 	real_ip_header X-Forwarded-For;
 	{{- end }}
 
-	log_format upstreaminfo '[$time_iso8601] - $remote_addr - $remote_user - $status - "$request" - $bytes_sent - "$http_referer" - "$http_user_agent" - "$server_name" - $upstream_addr - $http_host - $upstream_response_time - $request_time';
+	log_format upstreaminfo '[$time_iso8601] - $app_name - $remote_addr - $remote_user - $status - "$request" - $bytes_sent - "$http_referer" - "$http_user_agent" - "$server_name" - $upstream_addr - $http_host - $upstream_response_time - $request_time';
 
 	access_log /tmp/logpipe upstreaminfo;
 	error_log  /tmp/logpipe {{ $routerConfig.ErrorLogLevel }};
@@ -145,6 +145,7 @@ http {
 		server_name {{ if contains "." $domain }}{{ $domain }}{{ else if ne $routerConfig.PlatformDomain "" }}{{ $domain }}.{{ $routerConfig.PlatformDomain }}{{ else }}~^{{ $domain }}\.(?<domain>.+)${{ end }};
 		server_name_in_redirect off;
 		port_in_redirect off;
+		set $app_name "{{ $appConfig.Name }}";
 
 		{{ if index $appConfig.Certificates $domain }}
 		listen 6443 ssl{{ if $routerConfig.UseProxyProtocol }} proxy_protocol{{ end }};


### PR DESCRIPTION
This will help when there is a custom domain. Our monitoring solution is going to use this to parse out information

The namespace is prepended to the application name only when the namespace and app name (as known by the service) are not the same. This happens with the deis namespace

Generated config:

```
set $app_name "deis/deis-workflow-manager";
set $app_name "nearby-daffodil";
```

Querying against each of those

```
[06/May/2016:04:19:54 +0000][nearby-daffodil] - 10.2.19.1 - - - 200 - "GET / HTTP/1.1" - 178 - "-" - "curl/7.43.0" - "~^nearby-daffodil\x5C.(?<domain>.+)$" - 10.3.0.107:80 - nearby-daffodil.micro-kube.io - 0.006 - 0.006

> 06/May/2016:04:20:27 +0000][deis/deis-workflow-manager] - 10.2.19.1 - - - 404 - "GET / HTTP/1.1" - 221 - "-" - "curl/7.43.0" - "~^deis-workflow-manager\x5C.(?<domain>.+)$" - 10.3.0.130:80 - deis-workflow-manager.micro-kube.io - 0.048 - 0.048
```