### PR TITLE
docs(README): add codecov.io badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ manifests/deis-router-rc.tmp.yaml
 rootfs/opt/router/sbin/router
 rootfs/opt/router/sbin/router.*
 vendor/
+coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ services:
 install:
 - make bootstrap
 script:
-  - make build test
+  - make build test-cover
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Deis Router v2
 
 [![Build Status](https://travis-ci.org/deis/router.svg?branch=master)](https://travis-ci.org/deis/router)
+[![codecov.io](https://codecov.io/github/deis/router/coverage.svg?branch=master)](https://codecov.io/github/deis/router?branch=master)
 [![Go Report Card](http://goreportcard.com/badge/deis/router)](http://goreportcard.com/report/deis/router)
 [![Docker Repository on Quay](https://quay.io/repository/deis/router/status "Docker Repository on Quay")](https://quay.io/repository/deis/router)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  branch: master
+  slug: "deis/router"


### PR DESCRIPTION
# Summary of Changes

`make test-cover` runs the go unit tests while accumulating a `coverage.txt` file suitable for shipping to https://codecov.io/. This also adds a badge to README.md: [![codecov.io](https://codecov.io/github/deis/router/coverage.svg?branch=master)](https://codecov.io/github/deis/router?branch=master).