### PR TITLE
chore(ssl): Remove support for old cert secret format

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,8 +328,8 @@ Here is an example of a Kubernetes secret bearing a certificate for use with a s
 * Secret name must be for the form `<arbitrary name>-cert`
   * This must be associated to the domain using the [router.deis.io/certificates](#certificates-annotation) annotation.
 * Must be in the same namespace as the routable service
-* Certificate must be supplied as the value of the key `cert`
-* Certificate private key must be supplied as the value of the key `key`
+* Certificate must be supplied as the value of the key `tls.crt`
+* Certificate private key must be supplied as the value of the key `tls.key`
 * Both the certificate and private key must be base64 encoded
 
 For example, assuming a routable service exists in the namespace `cheery-yardbird` and is configured with `www.example.com` among its domains, like so:
@@ -355,8 +355,8 @@ metadata:
   namespace: cheery-yardbird
 type: Opaque
 data:
-  cert: MT1...uDh==
-  key: MT1...MRp=
+  tls.crt: MT1...uDh==
+  tls.key: MT1...MRp=
 ```
 
 #### <a name="platform-cert"></a>Platform certificate
@@ -373,8 +373,8 @@ Here is an example of a Kubernetes secret bearing a wildcard certificate for use
 
 * Namespace must be the same namespace as the router
 * Name _must_ be `deis-router-platform-cert`
-* Certificate must be supplied as the value of the key `cert`
-* Certificate private key must be supplied as the value of the key `key`
+* Certificate must be supplied as the value of the key `tls.crt`
+* Certificate private key must be supplied as the value of the key `tls.key`
 * Both the certificate and private key must be base64 encoded
 
 For example:
@@ -387,8 +387,8 @@ metadata:
   namespace: deis
 type: Opaque
 data:
-  cert: LS0...tCg==
-  key: LS0...LQo=
+  tls.crt: LS0...tCg==
+  tls.key: LS0...LQo=
 ```
 
 #### SSL options

--- a/model/model.go
+++ b/model/model.go
@@ -394,20 +394,14 @@ func buildCertificate(certSecret *api.Secret, context string) (*Certificate, err
 	cert, ok := certSecret.Data["tls.crt"]
 	// If no cert is found in the secret, warn and return nil
 	if !ok {
-		cert, ok = certSecret.Data["cert"]
-		if !ok {
-			log.Printf("WARN: The k8s secret intended to convey the %s certificate contained no entry \"tls.crt\" or \"cert\".\n", context)
-			return nil, nil
-		}
+		log.Printf("WARN: The k8s secret intended to convey the %s certificate contained no entry \"tls.crt\".\n", context)
+		return nil, nil
 	}
 	key, ok := certSecret.Data["tls.key"]
 	// If no key is found in the secret, warn and return nil
 	if !ok {
-		key, ok = certSecret.Data["key"]
-		if !ok {
-			log.Printf("WARN: The k8s secret intended to convey the %s certificate key contained no entry \"tls.key\" or \"key\".\n", context)
-			return nil, nil
-		}
+		log.Printf("WARN: The k8s secret intended to convey the %s certificate key contained no entry \"tls.key\".\n", context)
+		return nil, nil
 	}
 	certStr := string(cert[:])
 	keyStr := string(key[:])


### PR DESCRIPTION
#158 added support for differently formatted k8s secrets conveying SSL certs. The new format was intended to match that documented for use with ingresses [here](http://kubernetes.io/docs/user-guide/ingress/#tls). #158 was tactical, however, and retained support for the old format as well. Support for the old format should be removed (as was always intended) before we go GA.

cc @helgi 