### PR TITLE
fix(router): Improve accuracy of warning message

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -309,7 +309,7 @@ func buildRouterConfig(rc *api.ReplicationController, platformCertSecret *api.Se
 		return nil, err
 	}
 	if platformCertSecret != nil {
-		platformCertificate, err := buildCertificate(platformCertSecret, "default")
+		platformCertificate, err := buildCertificate(platformCertSecret, "platform")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Quite some time ago, we stopped referring to the platform domain and its cert as "default domain" or "default cert," since those have come to represent other things as the router's implementation has evolved.

This PR corrects an errant bit of text that ultimately could appear in a warning message, correcting it from "default" to "platform".