### PR TITLE
feat(*): add configurable server_tokens nginx setting, tests refactoring

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -51,6 +51,9 @@ type RouterConfig struct {
 	EnforceWhitelists        bool        `key:"enforceWhitelists" constraint:"(?i)^(true|false)$"`
 	DefaultWhitelist         []string    `key:"defaultWhitelist" constraint:"^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))?(\\s*,\\s*)?)+$"`
 	WhitelistMode            string      `key:"whitelistMode" constraint:"^(extend|override)$"`
+	DefaultServiceIP         string      `key:"defaultServiceIP"`
+	DefaultAppName           string      `key:"defaultAppName"`
+	DefaultServiceEnabled    bool        `key:"defaultServiceEnabled" constraint:"(?i)^(true|false)$"`
 	SSLConfig                *SSLConfig  `key:"ssl"`
 	AppConfigs               []*AppConfig
 	BuilderConfig            *BuilderConfig
@@ -68,11 +71,15 @@ func newRouterConfig() *RouterConfig {
 		GzipConfig:               newGzipConfig(),
 		BodySize:                 "1m",
 		ProxyRealIPCIDRs:         []string{"10.0.0.0/8"},
+		DisableServerTokens:      false,
 		ErrorLogLevel:            "error",
 		UseProxyProtocol:         false,
 		EnforceWhitelists:        false,
 		WhitelistMode:            "extend",
 		SSLConfig:                newSSLConfig(),
+		DefaultServiceEnabled:    false,
+		DefaultAppName:           "",
+		DefaultServiceIP:         "",
 	}
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -47,6 +47,7 @@ type RouterConfig struct {
 	ErrorLogLevel            string      `key:"errorLogLevel" constraint:"^(info|notice|warn|error|crit|alert|emerg)$"`
 	PlatformDomain           string      `key:"platformDomain" constraint:"(?i)^([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,}$"`
 	UseProxyProtocol         bool        `key:"useProxyProtocol" constraint:"(?i)^(true|false)$"`
+	DisableServerTokens      bool        `key:"disableServerTokens" constraint:"(?i)^(true|false)$"`
 	EnforceWhitelists        bool        `key:"enforceWhitelists" constraint:"(?i)^(true|false)$"`
 	DefaultWhitelist         []string    `key:"defaultWhitelist" constraint:"^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))?(\\s*,\\s*)?)+$"`
 	WhitelistMode            string      `key:"whitelistMode" constraint:"^(extend|override)$"`

--- a/model/model_validation_test.go
+++ b/model/model_validation_test.go
@@ -111,6 +111,14 @@ func TestValidEnforceWhitelists(t *testing.T) {
 	testValidValues(t, newTestRouterConfig, "EnforceWhitelists", "enforceWhitelists", []string{"true", "false", "TRUE", "FALSE"})
 }
 
+func TestValidServerTokens(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "DisableServerTokens", "disableServerTokens", []string{"true", "false", "TRUE", "FALSE"})
+}
+
+func TestInvalidServerTokens(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "DisableServerTokens", "disableServerTokens", []string{"0", "-1", "foobar"})
+}
+
 func TestInvalidDefaultWhitelist(t *testing.T) {
 	testInvalidValues(t, newTestRouterConfig, "DefaultWhitelist", "defaultWhitelist", []string{"0", "-1", "foobar"})
 }

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -48,6 +48,10 @@ http {
 
 	client_max_body_size {{ $routerConfig.BodySize }};
 
+	{{ if $routerConfig.DisableServerTokens -}}
+	server_tokens off;
+	{{- end}}
+
 	{{ range $realIPCIDR := $routerConfig.ProxyRealIPCIDRs -}}
 	set_real_ip_from {{ $realIPCIDR }};
 	{{ end -}}

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -116,31 +116,6 @@ http {
 	{{/* This means we force HTTPS if HSTS is enabled. */}}
 	{{ $enforceHTTPS := or $sslConfig.Enforce $hstsConfig.Enabled }}
 
-	# Default server handles requests for unmapped hostnames, including healthchecks
-	server {
-		listen 8080 default_server reuseport{{ if $routerConfig.UseProxyProtocol }} proxy_protocol{{ end }};
-		listen 6443 default_server ssl{{ if $routerConfig.UseProxyProtocol }} proxy_protocol{{ end }};
-		set $app_name "router-default-vhost";
-		{{ if $routerConfig.PlatformCertificate }}
-		ssl_protocols {{ $sslConfig.Protocols }};
-		ssl_certificate /opt/router/ssl/platform.crt;
-		ssl_certificate_key /opt/router/ssl/platform.key;
-		{{ else }}
-		ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-		ssl_certificate /opt/router/ssl/default/default.crt;
-		ssl_certificate_key /opt/router/ssl/default/default.key;
-		{{ end }}
-		server_name _;
-		location ~ ^/healthz/?$ {
-			access_log off;
-			default_type 'text/plain';
-			return 200;
-		}
-		location / {
-			return 404;
-		}
-	}
-
 	# Healthcheck on 9090 -- never uses proxy_protocol
 	server {
 		listen 9090 default_server;
@@ -213,9 +188,42 @@ http {
 
 			proxy_pass http://{{$appConfig.ServiceIP}}:80;{{ else }}return 503;{{ end }}
 		}
+		
 	}
 
 	{{end}}{{end}}
+
+	{{if $routerConfig.DefaultServiceEnabled}}
+	server {
+		listen 8080 default_server{{ if $routerConfig.UseProxyProtocol }} proxy_protocol{{ end }};
+		server_name _;
+		server_name_in_redirect off;
+		port_in_redirect off;
+		set $app_name "{{ $routerConfig.DefaultAppName }}";
+
+		vhost_traffic_status_filter_by_set_key {{ $routerConfig.DefaultAppName }} application::*;
+
+		location ~ ^/healthz/?$ {
+			access_log off;
+			default_type 'text/plain';
+			return 200;
+		}
+		
+		location / {
+			proxy_buffering off;
+			proxy_set_header Host $host;
+			proxy_set_header X-Forwarded-For $remote_addr;
+			proxy_set_header X-Forwarded-Proto $access_scheme;
+			proxy_set_header X-Forwarded-Port $forwarded_port;
+			proxy_redirect off;
+			proxy_http_version 1.1;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection $connection_upgrade;
+
+			proxy_pass http://{{$routerConfig.DefaultServiceIP}}:80;
+		}
+	}
+	{{end}}
 }
 
 {{ if $routerConfig.BuilderConfig }}{{ $builderConfig := $routerConfig.BuilderConfig }}stream {

--- a/nginx/config_test.go
+++ b/nginx/config_test.go
@@ -1,0 +1,74 @@
+package nginx
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+	"text/template"
+
+	"github.com/Masterminds/sprig"
+	"github.com/deis/router/model"
+)
+
+func TestDisableServerTokens(t *testing.T) {
+	routerConfig := &model.RouterConfig{
+		WorkerProcesses:          "auto",
+		MaxWorkerConnections:     "768",
+		TrafficStatusZoneSize:    "1m",
+		DefaultTimeout:           "1300s",
+		ServerNameHashMaxSize:    "512",
+		ServerNameHashBucketSize: "64",
+		GzipConfig: &model.GzipConfig{
+			Enabled:     true,
+			CompLevel:   "5",
+			Disable:     "msie6",
+			HTTPVersion: "1.1",
+			MinLength:   "256",
+			Proxied:     "any",
+			Types:       "application/atom+xml application/javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component",
+			Vary:        "on",
+		},
+		BodySize:          "1m",
+		ProxyRealIPCIDRs:  []string{"10.0.0.0/8"},
+		ErrorLogLevel:     "error",
+		UseProxyProtocol:  false,
+		EnforceWhitelists: false,
+		WhitelistMode:     "extend",
+		SSLConfig: &model.SSLConfig{
+			Enforce:           false,
+			Protocols:         "TLSv1 TLSv1.1 TLSv1.2",
+			SessionTimeout:    "10m",
+			UseSessionTickets: true,
+			BufferSize:        "4k",
+			HSTSConfig: &model.HSTSConfig{
+				Enabled:           false,
+				MaxAge:            15552000, // 180 days
+				IncludeSubDomains: false,
+				Preload:           false,
+			},
+		},
+
+		DisableServerTokens: true,
+	}
+
+	var b bytes.Buffer
+
+	tmpl, err := template.New("nginx").Funcs(sprig.TxtFuncMap()).Parse(confTemplate)
+
+	if err != nil {
+		t.Fatalf("Encountered an error: %v", err)
+	}
+
+	err = tmpl.Execute(&b, routerConfig)
+
+	if err != nil {
+		t.Fatalf("Encountered an error: %v", err)
+	}
+
+	validDirective := regexp.MustCompile(`(?m)^(\s*)server_tokens off;$`)
+
+	if !validDirective.Match(b.Bytes()) {
+		t.Errorf("Expected: 'server_tokens off' in the configuration. Actual: no match")
+	}
+
+}


### PR DESCRIPTION
There are two significant changes to this PR. I'm marking this as in progress and to start a conversation:

1) Add a `server_tokens` configurable field to for the nginx conf. This enables users to disable the Server response header field as documented [here](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens).

2) Begin adding tests to the nginx module. This will involve a refactoring of the module to allow dependency injection and converting to use writers/buffers rather than directly writing files. This'll also harden the codebase and allow testability. Right now, these changes are encapsulated in the test file, but the intent is to refactor both `model` and `nginx` packages to support testability.

Changes I'd like to make:
- [ ] Convert functions to take `io.Writer`/`io.Reader` instead of filenames
- [ ] 100% coverage on template options. Still debating the right way to get coverage on this (after template compilation)
- [ ] Make router models more easily exposed or isolatable in tests to reduce test dependencies
- [ ] Add defaults to the template to allow the uninstantiated configs
- [ ] Somehow sanely test commands.go
