### PR TITLE
Enable HTTP/2 support in the router

### DIFF
--- a/nginx/config.go
+++ b/nginx/config.go
@@ -115,7 +115,7 @@ http {
 	# Default server handles requests for unmapped hostnames, including healthchecks
 	server {
 		listen 8080 default_server reuseport{{ if $routerConfig.UseProxyProtocol }} proxy_protocol{{ end }};
-		listen 6443 default_server ssl{{ if $routerConfig.UseProxyProtocol }} proxy_protocol{{ end }};
+		listen 6443 default_server ssl http2{{ if $routerConfig.UseProxyProtocol }} proxy_protocol{{ end }};
 		set $app_name "router-default-vhost";
 		{{ if $routerConfig.PlatformCertificate }}
 		ssl_protocols {{ $sslConfig.Protocols }};
@@ -166,7 +166,7 @@ http {
 		set $app_name "{{ $appConfig.Name }}";
 
 		{{ if index $appConfig.Certificates $domain }}
-		listen 6443 ssl{{ if $routerConfig.UseProxyProtocol }} proxy_protocol{{ end }};
+		listen 6443 ssl http2{{ if $routerConfig.UseProxyProtocol }} proxy_protocol{{ end }};
 		ssl_protocols {{ $sslConfig.Protocols }};
 		{{ if ne $sslConfig.Ciphers "" }}ssl_ciphers {{ $sslConfig.Ciphers }};{{ end }}
 		ssl_prefer_server_ciphers on;


### PR DESCRIPTION
This enables HTTP/2 over TLS in the DEIS Workflow router.

The config change is all that's needed, because NGINX is [already compiled with the http_v2 module](https://github.com/deis/router/blob/a8497aff73027d330abf39d27d92194ad93e61b9/rootfs/Dockerfile#L45) and ALPN support (provided by openssl 1.0.2+).

This fixes #204.

You can pull image [docker.io/felixbuenemann/router:canary](https://hub.docker.com/r/felixbuenemann/router/) for manual testing.