### PR TITLE
fix(router): BodySize config can be "0"

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -42,7 +42,7 @@ type RouterConfig struct {
 	ServerNameHashMaxSize    string      `key:"serverNameHashMaxSize" constraint:"^[1-9]\\d*[kKmM]?$"`
 	ServerNameHashBucketSize string      `key:"serverNameHashBucketSize" constraint:"^[1-9]\\d*[kKmM]?$"`
 	GzipConfig               *GzipConfig `key:"gzip"`
-	BodySize                 string      `key:"bodySize" constraint:"^[1-9]\\d*[kKmM]?$"`
+	BodySize                 string      `key:"bodySize" constraint:"^[0-9]\\d*[kKmM]?$"`
 	ProxyRealIPCIDRs         []string    `key:"proxyRealIpCidrs" constraint:"^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))?(\\s*,\\s*)?)+$"`
 	ErrorLogLevel            string      `key:"errorLogLevel" constraint:"^(info|notice|warn|error|crit|alert|emerg)$"`
 	PlatformDomain           string      `key:"platformDomain" constraint:"(?i)^([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,}$"`

--- a/model/model_validation_test.go
+++ b/model/model_validation_test.go
@@ -64,7 +64,7 @@ func TestValidServerNameHashBucketSize(t *testing.T) {
 }
 
 func TestInvalidBodySize(t *testing.T) {
-	testInvalidValues(t, newTestRouterConfig, "BodySize", "bodySize", []string{"0", "-1", "foobar"})
+	testInvalidValues(t, newTestRouterConfig, "BodySize", "bodySize", []string{"-1", "foobar"})
 }
 
 func TestValidBodySize(t *testing.T) {


### PR DESCRIPTION
Setting size to 0 disables checking of client request body size.

See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size