### PR TITLE
chore(.gitignore): Update to ignore deis-router-deployment.tmp.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 manifests/deis-router-rc.tmp.yaml
+manifests/deis-router-deployment.tmp.yaml
 rootfs/opt/router/sbin/router
 rootfs/opt/router/sbin/router.*
 vendor/


### PR DESCRIPTION
This was missed in #224 

cc @kmala 