### PR TITLE
feat(router): add app SSL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ _Note that Kubernetes annotation maps are all of Go type `map[string]string`.  A
 | <a name="app-connect-timeout"></a>routable application | service | [router.deis.io/connectTimeout](#app-connect-timeout) | `"30s"` | nginx `proxy_connect_timeout` setting expressed in units `ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `y`. |
 | <a name="app-tcp-timeout"></a>routable application | service | [router.deis.io/tcpTimeout](#app-tcp-timeout) | router's `defaultTimeout` | nginx `proxy_send_timeout` and `proxy_read_timeout` settings expressed in units `ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `y`. |
 | <a name="app-maintenance"></a>routable application | service | [router.deis.io/maintenance](#app-maintenance) | `"false"` | Whether the app is under maintenance so that all traffic for this app is redirected to a static maintenance page with an error code of `503`. |
+| <a name="ssl-enforce"></a>routable application | service | [router.deis.io/ssl.enforce](#ssl-enforce) | `"false"` | Whether to respond with a 301 for all HTTP requests with a permanent redirect to the HTTPS equivalent address. |
 
 #### Annotations by example
 

--- a/model/model.go
+++ b/model/model.go
@@ -112,7 +112,8 @@ type AppConfig struct {
 	CertMappings   map[string]string `key:"certificates" constraint:"(?i)^((([a-z0-9]+(-*[a-z0-9]+)*)|((\\*\\.)?[a-z0-9]+(-*[a-z0-9]+)*\\.)+[a-z0-9]+(-*[a-z0-9]+)+):([a-z0-9]+(-*[a-z0-9]+)*)(\\s*,\\s*)?)+$"`
 	Certificates   map[string]*Certificate
 	Available      bool
-	Maintenance    bool `key:"maintenance" constraint:"(?i)^(true|false)$"`
+	Maintenance    bool       `key:"maintenance" constraint:"(?i)^(true|false)$"`
+	SSLConfig      *SSLConfig `key:"ssl"`
 }
 
 func newAppConfig(routerConfig *RouterConfig) *AppConfig {
@@ -120,6 +121,7 @@ func newAppConfig(routerConfig *RouterConfig) *AppConfig {
 		ConnectTimeout: "30s",
 		TCPTimeout:     routerConfig.DefaultTimeout,
 		Certificates:   make(map[string]*Certificate, 0),
+		SSLConfig:      newSSLConfig(),
 	}
 }
 
@@ -165,8 +167,8 @@ type SSLConfig struct {
 
 func newSSLConfig() *SSLConfig {
 	return &SSLConfig{
-		Enforce:           false,
-		Protocols:         "TLSv1 TLSv1.1 TLSv1.2",
+		Enforce:   false,
+		Protocols: "TLSv1 TLSv1.1 TLSv1.2",
 		// Default cipher suite:
 		//  - Prefer 128-Bit over 256-Bit encryptions (lower overhead)
 		//  - Prefer GCM over EDH over RSA auth (for Forward Secrecy)

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -201,7 +201,7 @@ http {
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection $connection_upgrade;
 
-			{{ if $enforceHTTPS }}if ($access_scheme != "https") {
+			{{ if or $enforceHTTPS $appConfig.SSLConfig.Enforce }}if ($access_scheme != "https") {
 				return 301 https://$host$request_uri;
 			}{{ end }}
 


### PR DESCRIPTION
Allow an application to enforce SSL by annotating `router.deis.io/nginx.ssl.enforce` on their service.

closes #148

TODO

 - [x] manual test
 - [x] README updates