### PR TITLE
chore(Makefile): update to go-dev 0.17.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ REPO_PATH := github.com/deis/${SHORT_NAME}
 
 # The following variables describe the containerized development environment
 # and other build options
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.16.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.17.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_CMD := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
 DEV_ENV_CMD_INT := docker run -it --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}

--- a/model/model.go
+++ b/model/model.go
@@ -53,7 +53,7 @@ type RouterConfig struct {
 	AppConfigs               []*AppConfig
 	BuilderConfig            *BuilderConfig
 	PlatformCertificate      *Certificate
-	Http2Enabled             bool `key:"http2Enabled" constraint:"(?i)^(true|false)$"`
+	HTTP2Enabled             bool `key:"http2Enabled" constraint:"(?i)^(true|false)$"`
 }
 
 func newRouterConfig() *RouterConfig {
@@ -72,7 +72,7 @@ func newRouterConfig() *RouterConfig {
 		EnforceWhitelists:        false,
 		WhitelistMode:            "extend",
 		SSLConfig:                newSSLConfig(),
-		Http2Enabled:             true,
+		HTTP2Enabled:             true,
 	}
 }
 
@@ -165,15 +165,15 @@ type SSLConfig struct {
 
 func newSSLConfig() *SSLConfig {
 	return &SSLConfig{
-		Enforce:           false,
-		Protocols:         "TLSv1 TLSv1.1 TLSv1.2",
+		Enforce:   false,
+		Protocols: "TLSv1 TLSv1.1 TLSv1.2",
 		// Default cipher suite:
 		//  - Prefer 128-Bit over 256-Bit encryptions (lower overhead)
 		//  - Prefer GCM over EDH over RSA auth (for Forward Secrecy)
 		//  - Fallback to 112-Bit 3DES (mainly for IE 8 compatibility)
 		// Compatible: Firefox 1, Chrome 1, IE 7, Opera 5, Safari 1, Windows XP IE8, Android 2.3, Java 7
 		// Incompatible: Windows XP IE6, Java 6
-		// Source: https://wiki.mozilla.org/Security/Server_Side_TLS (intermediate compatiblity)
+		// Source: https://wiki.mozilla.org/Security/Server_Side_TLS (intermediate compatibility)
 		Ciphers:           "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS",
 		SessionTimeout:    "10m",
 		UseSessionTickets: true,

--- a/model/model_validation_test.go
+++ b/model/model_validation_test.go
@@ -127,12 +127,12 @@ func TestValidWhitelistMode(t *testing.T) {
 	testValidValues(t, newTestRouterConfig, "WhitelistMode", "whitelistMode", []string{"extend", "override"})
 }
 
-func TestValidHttp2Enabled(t *testing.T) {
-  testValidValues(t, newTestRouterConfig, "HttpEnabled", "http2Enabled", []string{"true", "false", "TRUE", "FALSE"})
+func TestValidHTTP2Enabled(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "HttpEnabled", "http2Enabled", []string{"true", "false", "TRUE", "FALSE"})
 }
 
-func TestInvalidHttp2Enabled(t *testing.T) {
-  testInvalidValues(t, newTestRouterConfig, "Http2Enabled", "http2Enabled", []string{"0", "-1", "foobar"})
+func TestInvalidHTTP2Enabled(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "HTTP2Enabled", "http2Enabled", []string{"0", "-1", "foobar"})
 }
 
 func TestInvalidGzipEnabled(t *testing.T) {

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -115,7 +115,7 @@ http {
 	# Default server handles requests for unmapped hostnames, including healthchecks
 	server {
 		listen 8080 default_server reuseport{{ if $routerConfig.UseProxyProtocol }} proxy_protocol{{ end }};
-		listen 6443 default_server ssl {{ if $routerConfig.Http2Enabled }}http2{{ end }} {{ if $routerConfig.UseProxyProtocol }}proxy_protocol{{ end }};
+		listen 6443 default_server ssl {{ if $routerConfig.HTTP2Enabled }}http2{{ end }} {{ if $routerConfig.UseProxyProtocol }}proxy_protocol{{ end }};
 		set $app_name "router-default-vhost";
 		{{ if $routerConfig.PlatformCertificate }}
 		ssl_protocols {{ $sslConfig.Protocols }};
@@ -166,7 +166,7 @@ http {
 		set $app_name "{{ $appConfig.Name }}";
 
 		{{ if index $appConfig.Certificates $domain }}
-		listen 6443 ssl {{ if $routerConfig.Http2Enabled }}http2{{ end }} {{ if $routerConfig.UseProxyProtocol }}proxy_protocol{{ end }};
+		listen 6443 ssl {{ if $routerConfig.HTTP2Enabled }}http2{{ end }} {{ if $routerConfig.UseProxyProtocol }}proxy_protocol{{ end }};
 		ssl_protocols {{ $sslConfig.Protocols }};
 		{{ if ne $sslConfig.Ciphers "" }}ssl_ciphers {{ $sslConfig.Ciphers }};{{ end }}
 		ssl_prefer_server_ciphers on;
@@ -311,8 +311,5 @@ func WriteConfig(routerConfig *model.RouterConfig, filePath string) error {
 		return err
 	}
 	err = tmpl.Execute(file, routerConfig)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/deis/base:0.2.0
+FROM quay.io/deis/base:0.3.1
 
 RUN adduser --system \
 	--shell /bin/bash \


### PR DESCRIPTION
Includes the go 1.7 toolchain: faster, smaller, better. See https://tip.golang.org/doc/go1.7.

Also updates the Docker base image to deis/base:0.3.1.