### PR TITLE
fix(nginx): Enable builder PROXY PROTOCOL support

### DIFF
--- a/nginx/config.go
+++ b/nginx/config.go
@@ -247,7 +247,7 @@ http {
 
 {{ if $routerConfig.BuilderConfig }}{{ $builderConfig := $routerConfig.BuilderConfig }}stream {
 	server {
-		listen 2222;
+		listen 2222 {{ if $routerConfig.UseProxyProtocol }}proxy_protocol{{ end }};
 		proxy_connect_timeout {{ $builderConfig.ConnectTimeout }};
 		proxy_timeout {{ $builderConfig.TCPTimeout }};
 		proxy_pass {{$builderConfig.ServiceIP}}:2222;


### PR DESCRIPTION
If proxy protocol is enabled on an AWS ELB in kubernetes using the
`service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'`
annotation on the load balancer service, it will enable PROXY PROTOCOL
on all ports forwarded by the ELB, which means the builder proxy on port
2222 also needs to use `proxy_protocol` on its `listen` directive.

There is currently no way to configure PROXY PROTOCOL per port on AWS
using kubenetes service annotation and it doesn't really make sense to
enable proxy protocol only for port 80 and 443 anyways, so this fix uses
the same configuration setting as is used for http and https.

The required `proxy_protocol` option for the `listen` directive was [added in NGINX 1.11.4](https://nginx.org/en/docs/stream/ngx_stream_core_module.html#listen).

This fixes #255.