### PR TITLE
feat(nginx): ssl client certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ _Note that Kubernetes annotation maps are all of Go type `map[string]string`.  A
 | <a name="default-whitelist"></a>deis-router | deployment | [router.deis.io/nginx.defaultWhitelist](#default-whitelist) | N/A | A default (router-wide) whitelist expressed as  a comma-delimited list of addresses (using IP or CIDR notation).  Application-specific whitelists can either extend or override this default. |
 | <a name="whitelist-mode"></a>deis-router | deployment | [router.deis.io/nginx.whitelistMode](#whitelist-mode) | `"extend"` | Whether application-specific whitelists should extend or override the router-wide default whitelist (if defined).  Valid values are `"extend"` and `"override"`. |
 | <a name="http2-enabled"></a>deis-router | deployment | [router.deis.io/nginx.http2Enabled](#http2-enabled) | `"true"` | Whether to enable HTTP2 for apps on the SSL ports. |
+| <a name="client-certificates"></a>deis-router | deployment | [router.deis.io/nginx.clientCertificates](#client-certificates) | N/A | Comma separated list of base64ed PEM certificates. Certificates are saved to a file and used with nginx's `ssl_client_certificate` setting. If any certificates are present, nginx's `ssl_verify_client` will be set to `"on"` |
 | <a name="ssl-enforce"></a>deis-router | deployment | [router.deis.io/nginx.ssl.enforce](#ssl-enforce) | `"false"` | Whether to respond with a 301 for all HTTP requests with a permanent redirect to the HTTPS equivalent address. |
 | <a name="ssl-protocols"></a>deis-router | deployment | [router.deis.io/nginx.ssl.protocols](#ssl-protocols) | `"TLSv1 TLSv1.1 TLSv1.2"` | nginx `ssl_protocols` setting. |
 | <a name="ssl-ciphers"></a>deis-router | deployment | [router.deis.io/nginx.ssl.ciphers](#ssl-ciphers) | `"ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS"` | nginx `ssl_ciphers`.  The default ciphers are taken from the intermediate compatibility section in the [Mozilla Wiki on Security/Server Side TLS](https://wiki.mozilla.org/Security/Server_Side_TLS). If the value is set to the empty string, OpenSSL's default ciphers are used.  In _all_ cases, server side cipher preferences (order matters) are used. |
@@ -401,6 +402,14 @@ data:
 When combined with a good certificate, the router's _default_ SSL options are sufficient to earn an A grade from [Qualys SSL Labs](https://www.ssllabs.com/ssltest/analyze.html).
 
 Earning an A+ is as easy as simply enabling HTTP Strict Transport Security (see the `router.deis.io/nginx.ssl.hsts.enabled` option), but be aware that this will implicitly trigger the `router.deis.io/nginx.ssl.enforce` option and cause your applications to permanently use HTTPS for _all_ requests.
+
+#### Client Certificates
+
+The deis-router can enforce that clients are only allowed to talk with your routable applications when clients provide a client certificate. Clients without the correct client cerficate will be denied at the router. 
+
+Client certificate enforcement is activated when the `router.deis.io/nginx.clientCertificates` annotation on the deis-router deployment is set to contain a base64 encoded certificate. Multiple certificates can be specified with comma separated values.
+
+Client certificants, when configured, are active on all applications/domains where deis-router is configured to use ssl. Using application-specific ssl certificates will turn on client-certificate verification for those applications. Using a platform domain and a platform certificate will turn on client-certificate verification for all routable applications.
 
 ### Front-facing load balancer
 

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -29,6 +29,7 @@ func TestBuildRouterConfig(t *testing.T) {
 				"router.deis.io/nginx.ssl.bufferSize":             "6k",
 				"router.deis.io/nginx.ssl.hsts.maxAge":            "1234",
 				"router.deis.io/nginx.ssl.hsts.includeSubDomains": "true",
+				"router.deis.io/nginx.clientCertificates":         "YXNkZg==,cXdlcnR5",
 			},
 			Labels: map[string]string{
 				"heritage": "deis",
@@ -88,6 +89,7 @@ func TestBuildRouterConfig(t *testing.T) {
 	sslConfig := newSSLConfig()
 	hstsConfig := newHSTSConfig()
 	platformCert := newCertificate("foo", "bar")
+	clientCerts := []string{"asdf", "qwerty"}
 
 	// A value not set in the deployment annotations (should be default value).
 	expectedConfig.MaxWorkerConnections = "768"
@@ -107,6 +109,7 @@ func TestBuildRouterConfig(t *testing.T) {
 	expectedConfig.SSLConfig = sslConfig
 
 	expectedConfig.PlatformCertificate = platformCert
+	expectedConfig.ClientCertificates = clientCerts
 
 	actualConfig, err := buildRouterConfig(&routerDeployment, &platformCertSecret, &dhParamSecret)
 	if err != nil {

--- a/model/model_validation_test.go
+++ b/model/model_validation_test.go
@@ -135,6 +135,14 @@ func TestInvalidHTTP2Enabled(t *testing.T) {
 	testInvalidValues(t, newTestRouterConfig, "HTTP2Enabled", "http2Enabled", []string{"0", "-1", "foobar"})
 }
 
+func TestValidClientCerts(t *testing.T) {
+	testValidValues(t, newTestRouterConfig, "ClientCertificates", "clientCertificates", []string{"asdf", "two==", "one=", "z+/xcv", "poiu,lkjh==", "poiu,lkjh==,a+/s=,b"})
+}
+
+func TestInvalidClientCerts(t *testing.T) {
+	testInvalidValues(t, newTestRouterConfig, "ClientCertificates", "clientCertificates", []string{"asdf===", ",asdf==", "asdf=,", "asdf,,asdf", "", "=", "wi#a=="})
+}
+
 func TestInvalidGzipEnabled(t *testing.T) {
 	testInvalidValues(t, newTestGzipConfig, "Enabled", "enabled", []string{"0", "-1", "foobar"})
 }

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/Masterminds/sprig"
@@ -142,6 +143,11 @@ http {
 		ssl_certificate /opt/router/ssl/default/default.crt;
 		ssl_certificate_key /opt/router/ssl/default/default.key;
 		{{ end }}
+		{{ if $routerConfig.ClientCertificates }}
+		ssl_client_certificate /opt/router/ssl/client.ca.crt;
+		ssl_verify_client on;
+		{{ end }}
+
 		server_name _;
 		location ~ ^/healthz/?$ {
 			access_log off;
@@ -193,6 +199,12 @@ http {
 		ssl_session_tickets {{ if $sslConfig.UseSessionTickets }}on{{ else }}off{{ end }};
 		ssl_buffer_size {{ $sslConfig.BufferSize }};
 		{{ if ne $sslConfig.DHParam "" }}ssl_dhparam /opt/router/ssl/dhparam.pem;{{ end }}
+
+		{{ if $routerConfig.ClientCertificates }}
+		ssl_client_certificate /opt/router/ssl/client.ca.crt;
+		ssl_verify_client on;
+		{{ end }}
+
 		{{ end }}
 
 		{{ if or $routerConfig.EnforceWhitelists (or (ne (len $routerConfig.DefaultWhitelist) 0) (ne (len $appConfig.Whitelist) 0)) }}
@@ -232,7 +244,7 @@ http {
 
 			{{ if $hstsConfig.Enabled }}add_header Strict-Transport-Security $sts always;{{ end }}
 
-			proxy_pass http://{{$appConfig.ServiceIP}}:80;{{ else }}return 503;{{ end }}
+			proxy_pass http://{{$appConfig.ServiceIP}}:80;{{/* end of $appConfig.Available */}}{{ else }}return 503;{{ end }}
 		}
 		{{ if $appConfig.Maintenance }}error_page 503 @maintenance;
 			location @maintenance {
@@ -293,6 +305,12 @@ func WriteCerts(routerConfig *model.RouterConfig, sslPath string) error {
 				}
 			}
 		}
+	}
+
+	certPath := filepath.Join(sslPath, "client.ca.crt")
+	err = ioutil.WriteFile(certPath, []byte(strings.Join(routerConfig.ClientCertificates, "\n")), 0644)
+	if err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
This pull requests adds ssl client certificate functionality to the deis-router. Users can configure their deis-router to lock-down their apps with client certificates. When configured, the deis-router will reject any incoming connections that don't have the correct client certificate.

This pull request includes:
1. model.go code for reading new annotations from router deployment
2. config.go code for writing nginx config
3. expansion of existing tests to cover ssl client certificate functionality
4. configuration spec added to annotations table in README.md
5. Brief 3-paragraph description in README.md