### PR TITLE
feat(charts): Add support to add annotations during install

### DIFF
--- a/charts/router/templates/router-deployment.yaml
+++ b/charts/router/templates/router-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
     heritage: deis
   annotations:
     component.deis.io/version: {{ .Values.docker_tag }}
+{{- range $key, $value := .Values.deployment_annotations }}
+    {{ $key }}: {{ $value }}
+{{- end }}
 {{- if not (empty .Values.platform_domain) }}
     router.deis.io/nginx.platformDomain: {{ .Values.platform_domain }}
 {{- end }}

--- a/charts/router/templates/router-service.yaml
+++ b/charts/router/templates/router-service.yaml
@@ -2,6 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: deis-router
+{{- if .Values.service_annotations }}
+  annotations:
+{{- range $key, $value := .Values.service_annotations }}
+    {{ $key }}: {{ $value }}
+{{- end }}
+{{- end }}
   labels:
     heritage: deis
 spec:

--- a/charts/router/values.yaml
+++ b/charts/router/values.yaml
@@ -5,3 +5,13 @@ platform_domain: ""
 dhparam: ""
 # limits_cpu: "100m"
 # limits_memory: "50Mi"
+
+# Any custom router annotations(https://github.com/deis/router#annotations)
+# which need to be applied can be specified as key-value pairs under "deployment_annotations"
+deployment_annotations:
+  #<example-key>: <example-value>
+
+# Any custom annotations for k8s services like http://kubernetes.io/docs/user-guide/services/#ssl-support-on-aws
+# which need to be applied can be specified as key-value pairs under "service_annotations"
+service_annotations:
+  #<example-key>: <example-value>


### PR DESCRIPTION
fixes https://github.com/deis/charts/issues/374

This is useful if any user wants to have default annotations for all his cluster installs by using the same values file for all installs thereby not needing to do custom changes after the install.