### PR TITLE
fix(charts): enable hostports by default

### DIFF
--- a/charts/router/values.yaml
+++ b/charts/router/values.yaml
@@ -18,7 +18,7 @@ service_annotations:
 
 # Enable to pin router pod hostPort when using minikube or vagrant
 host_port:
-  enabled: false
+  enabled: true
 
 # Service type default to LoadBalancer 
 # service_type: LoadBalancer


### PR DESCRIPTION
This was the old default behaviour and is expected. Changing it to disabled by default is a regression. change was introduced in #296

cc @lachie83 for visibility, does this impact you in any way?