### PR TITLE
feat(charts): add resource requests to chart

### DIFF
--- a/charts/router/templates/router-deployment.yaml
+++ b/charts/router/templates/router-deployment.yaml
@@ -32,8 +32,9 @@ spec:
       - name: deis-router
         image: quay.io/{{.Values.org}}/router:{{.Values.docker_tag}}
         imagePullPolicy: {{.Values.pull_policy}}
-{{- if or (.Values.limits_cpu) (.Values.limits_memory)}}
+{{- if or (.Values.limits_cpu) (.Values.limits_memory) (.Values.requests_cpu) (.Values.requests_memory)}}
         resources:
+{{- if or (.Values.limits_cpu) (.Values.limits_memory)}}
           limits:
 {{- if (.Values.limits_cpu) }}
             cpu: {{.Values.limits_cpu}}
@@ -41,7 +42,18 @@ spec:
 {{- if (.Values.limits_memory) }}
             memory: {{.Values.limits_memory}}
 {{- end}}
+{{- end}} {{/* end limits section */}}
+{{- if or (.Values.requests_cpu) (.Values.requests_memory)}}
+          requests:
+{{- if (.Values.requests_cpu) }}
+            cpu: {{.Values.requests_cpu}}
 {{- end}}
+{{- if (.Values.requests_memory) }}
+            memory: {{.Values.requests_memory}}
+{{- end}}
+{{- end}} {{/* end requests section */}}
+{{- end}} {{/* end resources section */}}
+
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/charts/router/values.yaml
+++ b/charts/router/values.yaml
@@ -5,6 +5,8 @@ platform_domain: ""
 dhparam: ""
 # limits_cpu: "100m"
 # limits_memory: "50Mi"
+# requests_cpu: "100m"
+# requests_memory: "50Mi"
 
 # Any custom router annotations(https://github.com/deis/router#annotations)
 # which need to be applied can be specified as key-value pairs under "deployment_annotations"


### PR DESCRIPTION
- this allows the router to be used in a horizontal pod autoscaler out the the box. Without `resources.requests`, the HPA can't calculate a `CURRENT` value