### PR TITLE
fix(Dockerfile): force gunzip of license files

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -51,7 +51,7 @@ RUN buildDeps='gcc make libgeoip-dev libssl-dev libpcre3-dev'; \
     apt-get clean -y && \
     # package up license files if any by appending to existing tar
     COPYRIGHT_TAR='/usr/share/copyrights.tar'; \
-    gunzip $COPYRIGHT_TAR.gz; tar -rf $COPYRIGHT_TAR /usr/share/doc/*/copyright; gzip $COPYRIGHT_TAR && \
+    gunzip -f $COPYRIGHT_TAR.gz; tar -rf $COPYRIGHT_TAR /usr/share/doc/*/copyright; gzip $COPYRIGHT_TAR && \
     rm -rf \
         /usr/share/doc \
         /usr/share/man \


### PR DESCRIPTION
I run into errors building router locally without this change. See also deis/controller#1203 and deis/builder#475.