### PR TITLE
fix(style): Apply mandatory formatting fixes

### DIFF
--- a/model/model_test.go
+++ b/model/model_test.go
@@ -138,7 +138,7 @@ func TestBuildBuilderConfig(t *testing.T) {
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
-				v1.ServicePort{
+				{
 					Name: "ssh",
 					Port: int32(2222),
 					TargetPort: intstr.IntOrString{

--- a/nginx/config_test.go
+++ b/nginx/config_test.go
@@ -44,9 +44,9 @@ func TestWriteCerts(t *testing.T) {
 			Key:  expectedPlatformKey,
 		},
 		AppConfigs: []*model.AppConfig{
-			&model.AppConfig{
+			{
 				Certificates: map[string]*model.Certificate{
-					"example.com": &model.Certificate{
+					"example.com": {
 						Cert: expectedExampleCrt,
 						Key:  expectedExampleKey,
 					},


### PR DESCRIPTION
I'm not at all sure how master got to a point where tests don't pass due to gofmt / lint issues, but that is indeed the case-- and it's going to stop other PRs I have in the pipeline from passing...

```
$ make test
docker run --rm -v /Users/kent/Code/go/src/github.com/deis/router:/go/src/github.com/deis/router -w /go/src/github.com/deis/router quay.io/deis/go-dev:v0.22.0 make style-check
lint
Manadatory Linters: These must pass
model/model_test.go:1::warning: file is not gofmted with -s (gofmt)
nginx/config_test.go:1::warning: file is not gofmted with -s (gofmt)
Optional Linters: These should pass
Makefile:94: recipe for target 'style-check' failed
make: *** [style-check] Error 1
make: *** [test-style] Error 2
```

This fixes it.