### PR TITLE
fix(.travis.yml): Make travis apply style checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ env:
 install:
 - make bootstrap
 script:
-  - make build test-cover
+- make build test-style test-cover
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+- bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This makes travis apply style checks. It's a pretty big oversight that it isn't currently.

This also includes minor formatting fixes to `.travis.yml` itself.

Note: this will fail until #320 is merged.