### PR TITLE
fix(charts): quote annotation values

### DIFF
--- a/charts/router/templates/router-deployment.yaml
+++ b/charts/router/templates/router-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     component.deis.io/version: {{ .Values.docker_tag }}
 {{- range $key, $value := .Values.deployment_annotations }}
-    {{ $key }}: {{ $value }}
+    {{ $key }}: {{ quote $value }}
 {{- end }}
 {{- if not (empty .Values.platform_domain) }}
     router.deis.io/nginx.platformDomain: {{ .Values.platform_domain }}

--- a/charts/router/templates/router-service.yaml
+++ b/charts/router/templates/router-service.yaml
@@ -5,7 +5,7 @@ metadata:
 {{- if .Values.service_annotations }}
   annotations:
 {{- range $key, $value := .Values.service_annotations }}
-    {{ $key }}: {{ $value }}
+    {{ $key }}: {{ quote $value }}
 {{- end }}
 {{- end }}
   labels:


### PR DESCRIPTION
I get errors trying to set `service_annotations` or `deployment_annotations` in testing #323. Templating the router service seems to be the initial problem, because the `range` loop doesn't quote the values as required.

Closes #325.