### PR TITLE
ref(charts): disable host_port/enabled by default

### DIFF
--- a/charts/router/values.yaml
+++ b/charts/router/values.yaml
@@ -18,7 +18,7 @@ service_annotations:
 
 # Enable to pin router pod hostPort when using minikube or vagrant
 host_port:
-  enabled: true
+  enabled: false
 
 # Service type default to LoadBalancer 
 # service_type: LoadBalancer


### PR DESCRIPTION
Host ports on some cloud providers like GKE play differently than expected.

cc @slack 