### PR TITLE
Add status endpoint

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -65,6 +65,7 @@ type RouterConfig struct {
 	HTTP2Enabled             bool                `key:"http2Enabled" constraint:"(?i)^(true|false)$"`
 	LogFormat                string              `key:"logFormat"`
 	ProxyBuffersConfig       *ProxyBuffersConfig `key:"proxyBuffers"`
+	StatusEndpoint           bool                `key:"statusEndpoint" constraint:"(?i)^(true|false)$"`
 }
 
 func newRouterConfig() (*RouterConfig, error) {
@@ -95,6 +96,7 @@ func newRouterConfig() (*RouterConfig, error) {
 		HTTP2Enabled:             true,
 		LogFormat:                `[$time_iso8601] - $app_name - $remote_addr - $remote_user - $status - "$request" - $bytes_sent - "$http_referer" - "$http_user_agent" - "$server_name" - $upstream_addr - $http_host - $upstream_response_time - $request_time`,
 		ProxyBuffersConfig:       proxyBuffersConfig,
+		StatusEndpoint:           false,
 	}, nil
 }
 

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -145,6 +145,12 @@ http {
 			return 200;
 		}
 
+    {{ if $routerConfig.statusEndpoint }}
+    location /nginx_status {
+      stub_status on;
+    }
+    {{ end }}
+
 		location / {
 			proxy_buffering {{ if $routerConfig.ProxyBuffersConfig.Enabled }}on{{ else }}off{{ end }};
 			proxy_buffer_size {{ $routerConfig.ProxyBuffersConfig.Size }};

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -186,6 +186,11 @@ http {
 		location / {
 			return 404;
 		}
+		{{ if $routerConfig.statusEndpoint }}
+		location /nginx_status {
+			stub_status on;
+		}
+		{{ end }}
 	}
 	{{ end }}
 

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -144,13 +144,13 @@ http {
 			default_type 'text/plain';
 			return 200;
 		}
-
     {{ if $routerConfig.statusEndpoint }}
     location /nginx_status {
       stub_status on;
+      allow 127.0.0.1;
+      deny all;
     }
     {{ end }}
-
 		location / {
 			proxy_buffering {{ if $routerConfig.ProxyBuffersConfig.Enabled }}on{{ else }}off{{ end }};
 			proxy_buffer_size {{ $routerConfig.ProxyBuffersConfig.Size }};
@@ -194,7 +194,9 @@ http {
 		}
 		{{ if $routerConfig.statusEndpoint }}
 		location /nginx_status {
-			stub_status on;
+      stub_status on;
+      allow 127.0.0.1;
+      deny all;
 		}
 		{{ end }}
 	}


### PR DESCRIPTION
I'd like to add a sysdig app chcek on the router, but it only installs the stub_status module, doesn't use it to expose the endpoint or provides configuration for it. 

@krancour What else would I need to submit to get this in? Is this even correct at all?