### PR TITLE
RBAC support

### DIFF
--- a/charts/router/templates/_helpers.tmpl
+++ b/charts/router/templates/_helpers.tmpl
@@ -1,0 +1,10 @@
+{{/*
+Set apiVersion based on Kubernetes version
+*/}}
+{{- define "rbacAPIVersion" -}}
+{{- if ge .Capabilities.KubeVersion.Minor "6" -}}
+rbac.authorization.k8s.io/v1beta1
+{{- else -}}
+rbac.authorization.k8s.io/v1alpha1
+{{- end -}}
+{{- end -}}

--- a/charts/router/templates/router-clusterrole.yaml
+++ b/charts/router/templates/router-clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: ClusterRole
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis:deis-router
+  labels:
+    app: deis-router
+    heritage: deis
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get"]
+{{- end -}}
+{{- end -}}

--- a/charts/router/templates/router-clusterrolebinding.yaml
+++ b/charts/router/templates/router-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis:deis-router
+  labels:
+    app: deis-router
+    heritage: deis
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: deis:deis-router
+subjects:
+- kind: ServiceAccount
+  name: deis-router
+  namespace: {{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}

--- a/charts/router/templates/router-role.yaml
+++ b/charts/router/templates/router-role.yaml
@@ -1,0 +1,15 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+apiVersion: {{ template "rbacAPIVersion" . }}
+kind: Role
+metadata:
+  labels:
+    app: deis-router
+    heritage: deis
+  name: deis-router
+rules:
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments"]
+  verbs: ["get"]
+{{- end -}}
+{{- end -}}

--- a/charts/router/templates/router-rolebinding.yaml
+++ b/charts/router/templates/router-rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: RoleBinding
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis-router
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: deis-router
+subjects:
+- kind: ServiceAccount
+  name: deis-router
+  namespace: {{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}

--- a/charts/router/values.yaml
+++ b/charts/router/values.yaml
@@ -22,7 +22,7 @@ dhparam: ""
 host_port:
   enabled: false
 
-# Service type default to LoadBalancer 
+# Service type default to LoadBalancer
 # service_type: LoadBalancer
 
 global:
@@ -32,3 +32,5 @@ global:
   # - true: The Deis router will NOT be deployed. Inherently workflow will not be usable until a Kubernetes ingress controller is installed.
   # - false: The default mode, and the default behavior of Deis workflow.
   experimental_native_ingress: false
+  # Role-Based Access Control for Kubernetes >= 1.5
+  use_rbac: false


### PR DESCRIPTION
With this change `deis-router` became available to work in **RBAC**-only clusters

Works with both Kubernetes 1.5 and 1.6 (see `templates/_helpers.tmpl` for details)
Actually tested with 1.5.7 and 1.6.2

Role allows `deis-router`:
- `extensions/deployments`: `get`
- `apps/deployments`: `get`

ClusterRole allows `deis-router`:
- `services`: `get` and `list`
- `secrets`: `get`
- `endpoints`: `get`