### PR TITLE
fix(nginx) wait for nginx reload to avoid zombies

### DIFF
--- a/nginx/commands.go
+++ b/nginx/commands.go
@@ -32,6 +32,9 @@ func Reload() error {
 	if err := cmd.Start(); err != nil {
 		return err
 	}
+	if err := cmd.Wait(); err != nil {
+		return err
+	}
 	log.Println("INFO: nginx reloaded.")
 	return nil
 }


### PR DESCRIPTION
If a unix process is spawned, the parent process must wait for its pid or the process will become a zombie after exit. This fixes the problem that the `/opt/router/sbin/router` binary leaves behing a defunct nginx process each time the config is reloaded by spawning "nginx -s reload".

Fixes #331.